### PR TITLE
Update names

### DIFF
--- a/source/Ubuntu-B.ufo/fontinfo.plist
+++ b/source/Ubuntu-B.ufo/fontinfo.plist
@@ -63,7 +63,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>openTypeNameUniqueID</key>
-		<string>DaltonMaagLtd: Ubuntu Bold 0.83</string>
+		<string>Ubuntu Bold Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-BI.ufo/fontinfo.plist
+++ b/source/Ubuntu-BI.ufo/fontinfo.plist
@@ -61,7 +61,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>openTypeNameUniqueID</key>
-		<string>DaltonMaagLtd: Ubuntu BoldItalic 0.83</string>
+		<string>Ubuntu BoldItalic Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-L.ufo/fontinfo.plist
+++ b/source/Ubuntu-L.ufo/fontinfo.plist
@@ -65,7 +65,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>openTypeNameUniqueID</key>
-		<string>DaltonMaagLtd: Ubuntu Light 0.83</string>
+		<string>Ubuntu Light Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-LI.ufo/fontinfo.plist
+++ b/source/Ubuntu-LI.ufo/fontinfo.plist
@@ -94,9 +94,9 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>openTypeNameUniqueID</key>
-		<string>DaltonMaagLtd: Ubuntu Light Italic 0.83</string>
+		<string>Ubuntu Light Italic Version 0.83</string>
 		<key>openTypeNameVersion</key>
-		<string>0.83</string>
+		<string>Version 0.83</string>
 		<key>openTypeOS2CodePageRanges</key>
 		<array>
 			<integer>0</integer>

--- a/source/Ubuntu-M.ufo/fontinfo.plist
+++ b/source/Ubuntu-M.ufo/fontinfo.plist
@@ -73,9 +73,9 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>openTypeNameUniqueID</key>
-		<string>DaltonMaagLtd: Ubuntu Medium 0.83</string>
+		<string>Ubuntu Medium Version 0.83</string>
 		<key>openTypeNameVersion</key>
-		<string>0.83</string>
+		<string>Version 0.83</string>
 		<key>openTypeOS2CodePageRanges</key>
 		<array>
 			<integer>0</integer>

--- a/source/Ubuntu-M.ufo/fontinfo.plist
+++ b/source/Ubuntu-M.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Light</string>
+		<string>Ubuntu Medium</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -223,11 +223,11 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>postscriptWindowsCharacterSet</key>
 		<integer>1</integer>
 		<key>styleMapFamilyName</key>
-		<string>Ubuntu Light</string>
+		<string>Ubuntu Medium</string>
 		<key>styleMapStyleName</key>
-		<string>bold</string>
+		<string>regular</string>
 		<key>styleName</key>
-		<string>Bold</string>
+		<string>Regular</string>
 		<key>trademark</key>
 		<string>Ubuntu and Canonical are registered trademarks of Canonical Ltd.</string>
 		<key>unitsPerEm</key>

--- a/source/Ubuntu-MI.ufo/fontinfo.plist
+++ b/source/Ubuntu-MI.ufo/fontinfo.plist
@@ -62,9 +62,9 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>openTypeNameUniqueID</key>
-		<string>DaltonMaagLtd: Ubuntu Medium Italic 0.83</string>
+		<string>Ubuntu Medium Italic Version 0.83</string>
 		<key>openTypeNameVersion</key>
-		<string>0.83</string>
+		<string>Version 0.83</string>
 		<key>openTypeOS2CodePageRanges</key>
 		<array>
 			<integer>0</integer>

--- a/source/Ubuntu-MI.ufo/fontinfo.plist
+++ b/source/Ubuntu-MI.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Light</string>
+		<string>Ubuntu Medium</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -220,11 +220,11 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>postscriptWindowsCharacterSet</key>
 		<integer>1</integer>
 		<key>styleMapFamilyName</key>
-		<string>Ubuntu Light</string>
+		<string>Ubuntu Medium</string>
 		<key>styleMapStyleName</key>
-		<string>bold italic</string>
+		<string>italic</string>
 		<key>styleName</key>
-		<string>Bold Italic</string>
+		<string>Italic</string>
 		<key>trademark</key>
 		<string>Ubuntu and Canonical are registered trademarks of Canonical Ltd.</string>
 		<key>unitsPerEm</key>

--- a/source/Ubuntu-R.ufo/fontinfo.plist
+++ b/source/Ubuntu-R.ufo/fontinfo.plist
@@ -79,9 +79,9 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>openTypeNameUniqueID</key>
-		<string>DaltonMaagLtd: Ubuntu Regular 0.83</string>
+		<string>Ubuntu Regular Version 0.83</string>
 		<key>openTypeNameVersion</key>
-		<string>0.83</string>
+		<string>Version 0.83</string>
 		<key>openTypeOS2CodePageRanges</key>
 		<array>
 			<integer>0</integer>

--- a/source/Ubuntu-R.ufo/fontinfo.plist
+++ b/source/Ubuntu-R.ufo/fontinfo.plist
@@ -200,7 +200,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptFontName</key>
-		<string>Ubuntu</string>
+		<string>Ubuntu-Regular</string>
 		<key>postscriptForceBold</key>
 		<false/>
 		<key>postscriptFullName</key>

--- a/source/Ubuntu-RI.ufo/fontinfo.plist
+++ b/source/Ubuntu-RI.ufo/fontinfo.plist
@@ -67,9 +67,9 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>openTypeNameUniqueID</key>
-		<string>DaltonMaagLtd: Ubuntu Regular 0.83</string>
+		<string>Ubuntu Regular Version 0.83</string>
 		<key>openTypeNameVersion</key>
-		<string>0.83</string>
+		<string>Version 0.83</string>
 		<key>openTypeOS2CodePageRanges</key>
 		<array>
 			<integer>0</integer>


### PR DESCRIPTION
This update names of B, BI, L, LI, M, MI, R, RI to match what was previously delivered as 0.831.
- M and MI are own family instead of being bold of Light (see [Bug #1512111](https://bugs.launchpad.net/ubuntu/+source/ubuntu-font-family-sources/+bug/1512111))
- name UniqueID string is formatted as "{family} {style} Version {version}"
- name Version string is formatted as "Version {version}"
