### PR TITLE
Fix head table flags

### DIFF
--- a/source/Ubuntu-LI.ufo/fontinfo.plist
+++ b/source/Ubuntu-LI.ufo/fontinfo.plist
@@ -63,6 +63,9 @@
 		<string>Ubuntu Light Italic</string>
 		<key>openTypeHeadFlags</key>
 		<array>
+			<integer>0</integer>
+			<integer>3</integer>
+			<integer>4</integer>
 		</array>
 		<key>openTypeHeadLowestRecPPEM</key>
 		<integer>9</integer>

--- a/source/Ubuntu-MI.ufo/fontinfo.plist
+++ b/source/Ubuntu-MI.ufo/fontinfo.plist
@@ -31,6 +31,9 @@
 		<string>Ubuntu Medium Italic</string>
 		<key>openTypeHeadFlags</key>
 		<array>
+			<integer>0</integer>
+			<integer>3</integer>
+			<integer>4</integer>
 		</array>
 		<key>openTypeHeadLowestRecPPEM</key>
 		<integer>9</integer>

--- a/source/UbuntuMono-B.ufo/fontinfo.plist
+++ b/source/UbuntuMono-B.ufo/fontinfo.plist
@@ -31,6 +31,7 @@
 		<string>Ubuntu Monospaced Bold</string>
 		<key>openTypeHeadFlags</key>
 		<array>
+			<integer>0</integer>
 		</array>
 		<key>openTypeHeadLowestRecPPEM</key>
 		<integer>9</integer>

--- a/source/UbuntuMono-BI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-BI.ufo/fontinfo.plist
@@ -39,6 +39,7 @@
 		<string>Ubuntu Monospaced Bold Italic</string>
 		<key>openTypeHeadFlags</key>
 		<array>
+			<integer>0</integer>
 		</array>
 		<key>openTypeHeadLowestRecPPEM</key>
 		<integer>9</integer>

--- a/source/UbuntuMono-R.ufo/fontinfo.plist
+++ b/source/UbuntuMono-R.ufo/fontinfo.plist
@@ -31,6 +31,7 @@
 		<string>Ubuntu Monospaced</string>
 		<key>openTypeHeadFlags</key>
 		<array>
+			<integer>0</integer>
 		</array>
 		<key>openTypeHeadLowestRecPPEM</key>
 		<integer>9</integer>

--- a/source/UbuntuMono-RI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-RI.ufo/fontinfo.plist
@@ -31,6 +31,7 @@
 		<string>Ubuntu Monospaced Italic</string>
 		<key>openTypeHeadFlags</key>
 		<array>
+			<integer>0</integer>
 		</array>
 		<key>openTypeHeadLowestRecPPEM</key>
 		<integer>9</integer>


### PR DESCRIPTION
Fixes head table flags for all Monospaced fonts (flag 0), and for Light Italic and Medium Italic (flags 0, 3 and 4). 
