### PR TITLE
Fix concurrent make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,8 @@ $(SRC_DIR)/%.ttf: $(SRC_DIR)/%.ufo $(SRC_DIR)/%.ufo/*.plist \
                   $(SRC_DIR)/%.ufo/glyphs*/contents.plist \
                   $(SRC_DIR)/%.ufo/data/com.github.fonttools.ttx/*.ttx
 	fontmake --keep-overlaps --no-production-names --keep-direction -o ttf -u $<
-	@FILE=$$(ls -t $(MASTER_DIR) | head -1); \
-	mv $(MASTER_DIR)/$$FILE $@;
-	@rm -r $(MASTER_DIR)
+	FILE=$$(python tools/print-fontmake-name.py $<); \
+	mv $(MASTER_DIR)/$$FILE.ttf $@;
 	@python -m vttLib merge $< $@
 
 $(BUILD_DIR)/%.ttf: $(SRC_DIR)/%.ttf
@@ -48,6 +47,7 @@ $(LEGACY_KERN_DIR)/%.ttf: $(SRC_DIR)/%.ufo $(BUILD_DIR)/%.ttf
 clean:
 	@rm -rf $(BUILD_DIR)
 	@rm -f $(VTT_TTF) $(VTT_MONO_TTF)
+	@rm -rf $(MASTER_DIR)
 
 update-requirements:
 	@bash tools/update-requirements.sh

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ LEGACY_KERN_TTF=$(ALL_FONTS:%=$(LEGACY_KERN_DIR)/$(NORMAL_NAME)-%.ttf)
 
 all: ttf
 
-ttf: $(TTF) $(MONO_TTF)
+ttf: $(TTF) $(MONO_TTF) $(LEGACY_KERN_TTF)
 
 vtt: $(VTT_TTF) $(VTT_MONO_TTF)
 
@@ -29,16 +29,18 @@ $(SRC_DIR)/%.ttf: $(SRC_DIR)/%.ufo $(SRC_DIR)/%.ufo/*.plist \
                   $(SRC_DIR)/%.ufo/features.fea \
                   $(SRC_DIR)/%.ufo/glyphs*/*.glif \
                   $(SRC_DIR)/%.ufo/glyphs*/contents.plist \
-                  $(SRC_DIR)/%.ufo/data/com.github.fonttools.ttx/*.ttx
-	fontmake --keep-overlaps --no-production-names --keep-direction -o ttf -u $<
+                  $(SRC_DIR)/%.ufo/data/com.github.fonttools.ttx/*.ttx \
+									$(SRC_DIR)/%.ufo/data/com.daltonmaag.vttLib.plist
+	@mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR) && \
+		fontmake --keep-overlaps --no-production-names --keep-direction -o ttf -u $(realpath $<)
 	FILE=$$(python tools/print-fontmake-name.py $<); \
-	mv $(MASTER_DIR)/$$FILE.ttf $@;
+	mv $(BUILD_DIR)/$(MASTER_DIR)/$$FILE.ttf $@;
 	@python -m vttLib merge $< $@
 
 $(BUILD_DIR)/%.ttf: $(SRC_DIR)/%.ttf
 	@mkdir -p $(BUILD_DIR)
 	@python -m vttLib compile --ship $< $@
-
 
 $(LEGACY_KERN_DIR)/%.ttf: $(SRC_DIR)/%.ufo $(BUILD_DIR)/%.ttf
 		@mkdir -p $(LEGACY_KERN_DIR)
@@ -47,7 +49,6 @@ $(LEGACY_KERN_DIR)/%.ttf: $(SRC_DIR)/%.ufo $(BUILD_DIR)/%.ttf
 clean:
 	@rm -rf $(BUILD_DIR)
 	@rm -f $(VTT_TTF) $(VTT_MONO_TTF)
-	@rm -rf $(MASTER_DIR)
 
 update-requirements:
 	@bash tools/update-requirements.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ubuntu Font Family
 
 The Ubuntu Font Family are a set of matching new libre/open fonts in
-development during 2010--2011.  And with further expansion work and
+development during 2010--2011, with further expansion work and
 bug fixing during 2015.  The development is being funded by
 Canonical Ltd on behalf the wider Free Software community and the
 Ubuntu project.  The technical font design work and implementation is
@@ -25,14 +25,9 @@ Install dependencies
 $ pip install -r requirements.txt
 ```
 
-Build fonts
+Build fonts and put them inside the `build/` directory.
 ```
 $ make
-```
-
-Add legacy kern table
-```
-$ make kerntable
 ```
 
 Build fonts to edit TrueType instructions in VTT (placed next to the UFO)

--- a/tools/print-fontmake-name.py
+++ b/tools/print-fontmake-name.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python
 #
 # Takes an .ufo file directory and prints the name fontmake 1.3.0 constructs for
 # the output binary. Used in the Makefile to find the file that a fontmake run

--- a/tools/print-fontmake-name.py
+++ b/tools/print-fontmake-name.py
@@ -1,0 +1,28 @@
+#!/bin/env python3
+#
+# Takes an .ufo file directory and prints the name fontmake 1.3.0 constructs for
+# the output binary. Used in the Makefile to find the file that a fontmake run
+# produced. Remove when fontmake grows an --output parameter.
+
+import argparse
+from ufoLib import UFOReader
+
+
+# An empty object that UFOReader can attach attributes to.
+class InfoObject(object):
+    pass
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "ufo", type=str, help="The path to the UFO whose name you want to print.")
+args = parser.parse_args()
+
+ufo = UFOReader(args.ufo)
+info = InfoObject()
+ufo.readInfo(info)
+
+name = '{}-{}'.format(info.familyName.replace(' ', ''),
+                      info.styleName.replace(' ', ''))
+
+print(name)


### PR DESCRIPTION
The Makefile contained a race condition that could mess up concurrent
builds with many processes. Fontmake is hardcoded to put binaries into a
master_* directory, the Makefile tried to move them out of there and then
delete the directory. This failed when concurrent makes were writing to
the same directory.

Fix it by not removing the master_ttf directory. Git will not pick it up
anyway, so no modification of .gitignore is needed.