### PR TITLE
Move maxp table metadata from lib.plist into data directory.

### DIFF
--- a/source/Ubuntu-B.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/Ubuntu-B.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1785</integer>
+		<key>maxStackElements</key>
+		<integer>1312</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/Ubuntu-B.ufo/lib.plist
+++ b/source/Ubuntu-B.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1785</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1312</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/Ubuntu-BI.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/Ubuntu-BI.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1785</integer>
+		<key>maxStackElements</key>
+		<integer>1312</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/Ubuntu-BI.ufo/lib.plist
+++ b/source/Ubuntu-BI.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1785</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1312</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/Ubuntu-C.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/Ubuntu-C.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1826</integer>
+		<key>maxStackElements</key>
+		<integer>1411</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/Ubuntu-C.ufo/lib.plist
+++ b/source/Ubuntu-C.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1826</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1411</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/Ubuntu-L.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/Ubuntu-L.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1785</integer>
+		<key>maxStackElements</key>
+		<integer>1312</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/Ubuntu-L.ufo/lib.plist
+++ b/source/Ubuntu-L.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1785</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1312</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/Ubuntu-LI.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/Ubuntu-LI.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1785</integer>
+		<key>maxStackElements</key>
+		<integer>1312</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/Ubuntu-LI.ufo/lib.plist
+++ b/source/Ubuntu-LI.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1785</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1312</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/Ubuntu-M.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/Ubuntu-M.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1785</integer>
+		<key>maxStackElements</key>
+		<integer>1312</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/Ubuntu-M.ufo/lib.plist
+++ b/source/Ubuntu-M.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1785</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1312</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/Ubuntu-MI.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/Ubuntu-MI.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1785</integer>
+		<key>maxStackElements</key>
+		<integer>1312</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/Ubuntu-MI.ufo/lib.plist
+++ b/source/Ubuntu-MI.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1785</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1312</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/Ubuntu-R.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/Ubuntu-R.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1785</integer>
+		<key>maxStackElements</key>
+		<integer>1312</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/Ubuntu-R.ufo/lib.plist
+++ b/source/Ubuntu-R.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1785</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1312</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/Ubuntu-RI.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/Ubuntu-RI.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1785</integer>
+		<key>maxStackElements</key>
+		<integer>1312</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/Ubuntu-RI.ufo/lib.plist
+++ b/source/Ubuntu-RI.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1785</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1312</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/UbuntuMono-B.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/UbuntuMono-B.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1967</integer>
+		<key>maxStackElements</key>
+		<integer>1447</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/UbuntuMono-B.ufo/lib.plist
+++ b/source/UbuntuMono-B.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1967</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1447</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/UbuntuMono-BI.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/UbuntuMono-BI.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1967</integer>
+		<key>maxStackElements</key>
+		<integer>1447</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/UbuntuMono-BI.ufo/lib.plist
+++ b/source/UbuntuMono-BI.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1967</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1447</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/UbuntuMono-R.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/UbuntuMono-R.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1967</integer>
+		<key>maxStackElements</key>
+		<integer>1447</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/UbuntuMono-R.ufo/lib.plist
+++ b/source/UbuntuMono-R.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1967</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>1447</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>

--- a/source/UbuntuMono-RI.ufo/data/com.daltonmaag.vttLib.plist
+++ b/source/UbuntuMono-RI.ufo/data/com.daltonmaag.vttLib.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>maxp</key>
+	<dict>
+		<key>maxFunctionDefs</key>
+		<integer>89</integer>
+		<key>maxInstructionDefs</key>
+		<integer>0</integer>
+		<key>maxSizeOfInstructions</key>
+		<integer>1571</integer>
+		<key>maxStackElements</key>
+		<integer>280</integer>
+		<key>maxStorage</key>
+		<integer>47</integer>
+		<key>maxTwilightPoints</key>
+		<integer>16</integer>
+		<key>maxZones</key>
+		<integer>2</integer>
+	</dict>
+</dict>
+</plist>

--- a/source/UbuntuMono-RI.ufo/lib.plist
+++ b/source/UbuntuMono-RI.ufo/lib.plist
@@ -2,20 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.robofont.robohint.maxp.maxFunctionDefs</key>
-		<integer>89</integer>
-		<key>com.robofont.robohint.maxp.maxInstructionDefs</key>
-		<integer>0</integer>
-		<key>com.robofont.robohint.maxp.maxSizeOfInstructions</key>
-		<integer>1571</integer>
-		<key>com.robofont.robohint.maxp.maxStackElements</key>
-		<integer>280</integer>
-		<key>com.robofont.robohint.maxp.maxStorage</key>
-		<integer>47</integer>
-		<key>com.robofont.robohint.maxp.maxTwilightPoints</key>
-		<integer>16</integer>
-		<key>com.robofont.robohint.maxp.maxZones</key>
-		<integer>2</integer>
 		<key>public.glyphOrder</key>
 		<array>
 			<string>.notdef</string>


### PR DESCRIPTION
vttLib says that the lib.plist way is deprecated, so redump the VTT data
into data/com.daltonmaag.vttLib.plist with `python -m vttLib dump
font.ttf font.ufo`

A `ttx` dump of the `maxp` table reveals no difference between Google Font's Ubuntu-Regular.ttf and a self-compiled Ubuntu-R.ttf.

Only caveat right now: concurrent make might fail with some syntax error that does not come up with a single-threaded run.