### PR TITLE
Mono fonts, head table: Set bit 3 in flags

### DIFF
--- a/source/UbuntuMono-B.ufo/fontinfo.plist
+++ b/source/UbuntuMono-B.ufo/fontinfo.plist
@@ -43,6 +43,7 @@
 		<key>openTypeHeadFlags</key>
 		<array>
 			<integer>0</integer>
+			<integer>3</integer>
 		</array>
 		<key>openTypeHeadLowestRecPPEM</key>
 		<integer>9</integer>

--- a/source/UbuntuMono-BI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-BI.ufo/fontinfo.plist
@@ -51,6 +51,7 @@
 		<key>openTypeHeadFlags</key>
 		<array>
 			<integer>0</integer>
+			<integer>3</integer>
 		</array>
 		<key>openTypeHeadLowestRecPPEM</key>
 		<integer>9</integer>

--- a/source/UbuntuMono-R.ufo/fontinfo.plist
+++ b/source/UbuntuMono-R.ufo/fontinfo.plist
@@ -43,6 +43,7 @@
 		<key>openTypeHeadFlags</key>
 		<array>
 			<integer>0</integer>
+			<integer>3</integer>
 		</array>
 		<key>openTypeHeadLowestRecPPEM</key>
 		<integer>9</integer>

--- a/source/UbuntuMono-RI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-RI.ufo/fontinfo.plist
@@ -43,6 +43,7 @@
 		<key>openTypeHeadFlags</key>
 		<array>
 			<integer>0</integer>
+			<integer>3</integer>
 		</array>
 		<key>openTypeHeadLowestRecPPEM</key>
 		<integer>9</integer>


### PR DESCRIPTION
The Google fonts release does it.

OpenType spec: "Bit 3: Force ppem to integer values for all internal
scaler math"