### PR TITLE
Set post table → underlinePosition to -123 for all fonts

### DIFF
--- a/source/Ubuntu-B.ufo/fontinfo.plist
+++ b/source/Ubuntu-B.ufo/fontinfo.plist
@@ -239,7 +239,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-183</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>120</integer>
 		<key>postscriptUniqueID</key>

--- a/source/Ubuntu-BI.ufo/fontinfo.plist
+++ b/source/Ubuntu-BI.ufo/fontinfo.plist
@@ -229,7 +229,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-183</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>120</integer>
 		<key>postscriptUniqueID</key>

--- a/source/Ubuntu-C.ufo/fontinfo.plist
+++ b/source/Ubuntu-C.ufo/fontinfo.plist
@@ -275,7 +275,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-162</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>79</integer>
 		<key>postscriptUniqueID</key>

--- a/source/Ubuntu-L.ufo/fontinfo.plist
+++ b/source/Ubuntu-L.ufo/fontinfo.plist
@@ -233,7 +233,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-133</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>56</integer>
 		<key>postscriptUniqueID</key>

--- a/source/Ubuntu-LI.ufo/fontinfo.plist
+++ b/source/Ubuntu-LI.ufo/fontinfo.plist
@@ -273,7 +273,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-133</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>20</integer>
 		<key>postscriptUniqueID</key>

--- a/source/Ubuntu-M.ufo/fontinfo.plist
+++ b/source/Ubuntu-M.ufo/fontinfo.plist
@@ -241,7 +241,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-133</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>20</integer>
 		<key>postscriptUniqueID</key>

--- a/source/Ubuntu-MI.ufo/fontinfo.plist
+++ b/source/Ubuntu-MI.ufo/fontinfo.plist
@@ -241,7 +241,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-133</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>20</integer>
 		<key>postscriptUniqueID</key>

--- a/source/Ubuntu-R.ufo/fontinfo.plist
+++ b/source/Ubuntu-R.ufo/fontinfo.plist
@@ -247,7 +247,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-162</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>79</integer>
 		<key>postscriptUniqueID</key>

--- a/source/Ubuntu-RI.ufo/fontinfo.plist
+++ b/source/Ubuntu-RI.ufo/fontinfo.plist
@@ -243,7 +243,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-162</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>79</integer>
 		<key>postscriptUniqueID</key>

--- a/source/UbuntuMono-B.ufo/fontinfo.plist
+++ b/source/UbuntuMono-B.ufo/fontinfo.plist
@@ -208,7 +208,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-133</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>20</integer>
 		<key>postscriptUniqueID</key>

--- a/source/UbuntuMono-BI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-BI.ufo/fontinfo.plist
@@ -216,7 +216,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-133</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>20</integer>
 		<key>postscriptUniqueID</key>

--- a/source/UbuntuMono-R.ufo/fontinfo.plist
+++ b/source/UbuntuMono-R.ufo/fontinfo.plist
@@ -208,7 +208,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-133</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>20</integer>
 		<key>postscriptUniqueID</key>

--- a/source/UbuntuMono-RI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-RI.ufo/fontinfo.plist
@@ -208,7 +208,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<array>
 		</array>
 		<key>postscriptUnderlinePosition</key>
-		<integer>-133</integer>
+		<integer>-123</integer>
 		<key>postscriptUnderlineThickness</key>
 		<integer>20</integer>
 		<key>postscriptUniqueID</key>


### PR DESCRIPTION
The GF version is using -123 across the board, except for Light (-105).