### PR TITLE
Fix hhea table for italics: set caret(Rise|Run) to what the GF version set

### DIFF
--- a/source/Ubuntu-BI.ufo/fontinfo.plist
+++ b/source/Ubuntu-BI.ufo/fontinfo.plist
@@ -67,6 +67,10 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
+		<key>openTypeHheaCaretSlopeRise</key>
+		<integer>1000</integer>
+		<key>openTypeHheaCaretSlopeRun</key>
+		<integer>240</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Bold Italic</string>
 		<key>openTypeNameDescription</key>

--- a/source/Ubuntu-LI.ufo/fontinfo.plist
+++ b/source/Ubuntu-LI.ufo/fontinfo.plist
@@ -111,6 +111,10 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
+		<key>openTypeHheaCaretSlopeRise</key>
+		<integer>1000</integer>
+		<key>openTypeHheaCaretSlopeRun</key>
+		<integer>240</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Light Italic</string>
 		<key>openTypeNameDescription</key>

--- a/source/Ubuntu-MI.ufo/fontinfo.plist
+++ b/source/Ubuntu-MI.ufo/fontinfo.plist
@@ -71,6 +71,10 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
+		<key>openTypeHheaCaretSlopeRise</key>
+		<integer>1000</integer>
+		<key>openTypeHheaCaretSlopeRun</key>
+		<integer>240</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Medium Italic</string>
 		<key>openTypeNameDescription</key>

--- a/source/Ubuntu-RI.ufo/fontinfo.plist
+++ b/source/Ubuntu-RI.ufo/fontinfo.plist
@@ -79,6 +79,10 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
+		<key>openTypeHheaCaretSlopeRise</key>
+		<integer>1000</integer>
+		<key>openTypeHheaCaretSlopeRun</key>
+		<integer>240</integer>
 		<key>openTypeNameDescription</key>
 		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
 

--- a/source/UbuntuMono-BI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-BI.ufo/fontinfo.plist
@@ -57,6 +57,10 @@
 		<integer>9</integer>
 		<key>openTypeHheaAscender</key>
 		<integer>830</integer>
+		<key>openTypeHheaCaretSlopeRise</key>
+		<integer>1000</integer>
+		<key>openTypeHheaCaretSlopeRun</key>
+		<integer>240</integer>
 		<key>openTypeHheaDescender</key>
 		<integer>-170</integer>
 		<key>openTypeHheaLineGap</key>

--- a/source/UbuntuMono-RI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-RI.ufo/fontinfo.plist
@@ -49,6 +49,10 @@
 		<integer>9</integer>
 		<key>openTypeHheaAscender</key>
 		<integer>830</integer>
+		<key>openTypeHheaCaretSlopeRise</key>
+		<integer>1000</integer>
+		<key>openTypeHheaCaretSlopeRun</key>
+		<integer>240</integer>
 		<key>openTypeHheaDescender</key>
 		<integer>-170</integer>
 		<key>openTypeHheaLineGap</key>


### PR DESCRIPTION
Not sure how relevant this is, but I copied them regardless. The other table differences (xMaxExtent, minLeftSideBearing, minRightSideBearing and numberOfHMetrics) are calculated by the compiler I guess.