### PR TITLE
Build hdmx, VDMX and LTSH tables by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ $(SRC_DIR)/%.ttf: $(SRC_DIR)/%.ufo $(SRC_DIR)/%.ufo/*.plist \
 $(BUILD_DIR)/%.ttf: $(SRC_DIR)/%.ttf
 	@mkdir -p $(BUILD_DIR)
 	python -m vttLib compile --ship $< $@
+	tools/update-hinted-metrics.sh $@
 
 clean:
 	@rm -rf $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ $(BUILD_DIR)/%.ttf: $(SRC_DIR)/%.ttf
 	@mkdir -p $(BUILD_DIR)
 	python -m vttLib compile --ship $< $@
 	tools/update-hinted-metrics.sh $@
+	python tools/postprocess-hdmx-zero_out_unif000.py $@
 
 clean:
 	@rm -rf $(BUILD_DIR)

--- a/tools/cachett-configuration-condensed.cfg
+++ b/tools/cachett-configuration-condensed.cfg
@@ -1,0 +1,14 @@
+[PixelHeightRange]
+8-200
+
+[VDMXResolutions]
+72:72, 60:72, 120:72
+300:300
+0:0
+
+[GlyphIndices]
+; recalculate All the glyphs in the font
+
+[hdmxPointSizes]
+11, 12, 13, 15, 16, 17, 19, 21, 24, 27, 29,
+32, 33, 37, 42, 46, 50, 54, 58, 67, 75, 83

--- a/tools/cachett-configuration-mono.cfg
+++ b/tools/cachett-configuration-mono.cfg
@@ -6,7 +6,3 @@
 
 [GlyphIndices]
 ; recalculate All the glyphs in the font
-
-[hdmxPointSizes]
-11, 12, 13, 15, 16, 17, 19, 21, 24, 27, 29,
-32, 33, 37, 42, 46, 50, 54, 58, 67, 75, 83

--- a/tools/cachett-configuration.cfg
+++ b/tools/cachett-configuration.cfg
@@ -1,0 +1,14 @@
+[PixelHeightRange]
+8-200
+
+[VDMXResolutions]
+72:72, 60:72, 120:72
+300:300
+0:0
+
+[GlyphIndices]
+; recalculate All the glyphs in the font
+
+[hdmxPointSizes]
+11, 12, 13, 15, 16, 17, 19, 20, 21, 23, 24, 25, 27, 28,
+29, 30, 32, 33, 35, 37, 38, 40, 42, 46, 50, 54, 58, 67

--- a/tools/postprocess-hdmx-zero_out_unif000.py
+++ b/tools/postprocess-hdmx-zero_out_unif000.py
@@ -21,6 +21,8 @@ if any(x in args.ttf for x in ("BI", "LI", "MI", "M")):
     for index, table in ttf["hdmx"].hdmx.items():
         table._array[table._map["uniF000"]] = 0
 
+    # As the cached (hdmx) width is zero, LTSH need not exist (and doesn't in
+    # the GF release of these fonts).
     del ttf["LTSH"].yPels["uniF000"]
 
     ttf.save(args.ttf)

--- a/tools/postprocess-hdmx-zero_out_unif000.py
+++ b/tools/postprocess-hdmx-zero_out_unif000.py
@@ -1,0 +1,24 @@
+#!/bin/env python3
+#
+# This is a hack to change the hdmx table widths for the uniF000 debug glyph to
+# zero against CacheTT's better judgment. Why? Because the Google Fonts release
+# (specifically BI, LI, MI and M) has the fields set to zero. REMOVE THIS ONCE
+# IT HAS BEEN PROVEN UNNECESSARY.
+
+import argparse
+import fontTools.ttLib
+
+parser = argparse.ArgumentParser()
+parser.add_argument("ttf", type=str, help="The path to the TTF to be modified.")
+args = parser.parse_args()
+
+# This only needs to be done in BI, LI, MI and M.
+if any(x in args.ttf for x in ("BI", "LI", "MI", "M")):
+    ttf = fontTools.ttLib.TTFont(args.ttf)
+
+    # The values can't be changed through the proper accessor methods, so access
+    # private fields directly.
+    for index, table in ttf["hdmx"].hdmx.items():
+        table._array[table._map["uniF000"]] = 0
+
+    ttf.save(args.ttf)

--- a/tools/postprocess-hdmx-zero_out_unif000.py
+++ b/tools/postprocess-hdmx-zero_out_unif000.py
@@ -21,4 +21,6 @@ if any(x in args.ttf for x in ("BI", "LI", "MI", "M")):
     for index, table in ttf["hdmx"].hdmx.items():
         table._array[table._map["uniF000"]] = 0
 
+    del ttf["LTSH"].yPels["uniF000"]
+
     ttf.save(args.ttf)

--- a/tools/update-hinted-metrics.sh
+++ b/tools/update-hinted-metrics.sh
@@ -1,0 +1,26 @@
+#!/bin/env bash
+#
+# Downloads CacheTT.exe (https://www.microsoft.com/en-us/Typography/tools.aspx)
+# and runs it with wine on the built font binaries to generate hdmx, VDMX and
+# LTSH tables (precached metrics of glyphs after hinting).
+#
+# Run from root directory like so: `update-hinted-metrics.sh font.ttf`.
+
+if [ ! -f tools/CacheTT/cachett.exe ]
+then
+  cd tools
+  curl -o FontTools.exe http://download.microsoft.com/download/f/f/a/ffae9ec6-3bf6-488a-843d-b96d552fd815/FontTools.exe
+  unzip FontTools.exe
+  unzip FontTools/CacheTT.zip
+  cd ..
+fi
+
+if [[ $1 == *"Ubuntu-C"* ]]
+then
+  CACHETT_CFG="tools/cachett-configuration-condensed.cfg"
+else
+  CACHETT_CFG="tools/cachett-configuration.cfg"
+fi
+
+wine tools/CacheTT/cachett.exe -V -TVDMX -TLTSH -Thdmx "$1" "$1_" $CACHETT_CFG
+mv "$1_" "$1"

--- a/tools/update-hinted-metrics.sh
+++ b/tools/update-hinted-metrics.sh
@@ -15,11 +15,24 @@ then
   cd ..
 fi
 
+CACHETT_CFG="tools/cachett-configuration.cfg"
+
+# The condensed face and the Mono fonts use different parameters:
+# 1) VDMX: cache values for sizes up to 255, only calculate for a 1:1 ratio.
+# 2) hdmx: the condensed face caches for fewer ppems.
 if [[ $1 == *"Ubuntu-C"* ]]
 then
   CACHETT_CFG="tools/cachett-configuration-condensed.cfg"
-else
-  CACHETT_CFG="tools/cachett-configuration.cfg"
+elif [[ $1 == *"UbuntuMono"* ]]
+then
+  CACHETT_CFG="tools/cachett-configuration-mono.cfg"
+fi
+
+# The Google Fonts version of Mono-BI does not ship with a VDMX table. As there
+# are no htmx or LTSH tables in the Mono fonts, we can go home now.
+if [[ $1 == *"UbuntuMono-BI"* ]]
+then
+  exit 0
 fi
 
 wine tools/CacheTT/cachett.exe -V -TVDMX -TLTSH -Thdmx "$1" "$1_" $CACHETT_CFG


### PR DESCRIPTION
This commit introduces a script that downloads Microsoft's font tools
(specifically CacheTT.exe) and invokes it through wine to build the
above tables.

So far I have only looked at the hdmx tables. Ubuntu-C (the Google Fonts
version) is special in that it carries computed metrics for fewer ppems.

Might add commits as I go further.