### PR TITLE
Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(SRC_DIR)/%.ttf: $(SRC_DIR)/%.ufo $(SRC_DIR)/%.ufo/*.plist \
 $(BUILD_DIR)/%.ttf: $(SRC_DIR)/%.ttf
 	@mkdir -p $(BUILD_DIR)
 	python -m vttLib compile --ship $< $@
-	tools/update-hinted-metrics.sh $@
+	bash tools/update-hinted-metrics.sh $@
 	python tools/postprocess-hdmx-zero_out_unif000.py $@
 
 clean:

--- a/tools/build.py
+++ b/tools/build.py
@@ -56,9 +56,9 @@ def legacy_kern_table(ufo):
 #
 # Reminder from http://unifiedfontobject.org/versions/ufo3/kerning.plist/:
 # Kerning groups must begin with standard prefixes. The prefix for groups
-# intended for use in the first side of a kerning pair is “public.kern1.”. The
+# intended for use in the first side of a kerning pair is "public.kern1.". The
 # prefix for groups intended for use in the second side of a kerning pair is
-# “public.kern2.”.
+# "public.kern2.".
 def flatten_kerning(ufo, key_glyphs_only=False):
     kerning = {}
     for (first, second), offset in ufo.kerning.items():

--- a/tools/postprocess-hdmx-zero_out_unif000.py
+++ b/tools/postprocess-hdmx-zero_out_unif000.py
@@ -13,7 +13,8 @@ parser.add_argument("ttf", type=str, help="The path to the TTF to be modified.")
 args = parser.parse_args()
 
 # This only needs to be done in BI, LI, MI and M.
-if any(x in args.ttf for x in ("BI", "LI", "MI", "M")):
+if any(x in args.ttf \
+  for x in ("Ubuntu-BI.ttf", "Ubuntu-LI.ttf", "Ubuntu-MI.ttf", "Ubuntu-M.ttf")):
     ttf = fontTools.ttLib.TTFont(args.ttf)
 
     # The values can't be changed through the proper accessor methods, so access


### PR DESCRIPTION
Minor changes.

The changes to postprocess-hdmx-zero_out_unif000.py probably fix an innocuous
bug in thehandling of UbuntuMono-* which the script triggers on because of the
"M".