### PR TITLE
Gpos fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ $(BUILD_DIR)/%.ttf: $(SRC_DIR)/%.ttf
 	python -m vttLib compile --ship $< $@
 	tools/update-hinted-metrics.sh $@
 	python tools/postprocess-hdmx-zero_out_unif000.py $@
+	python tools/postprocess-kern.py $@
 
 clean:
 	@rm -rf $(BUILD_DIR)

--- a/source/Ubuntu-B.ufo/kerning.plist
+++ b/source/Ubuntu-B.ufo/kerning.plist
@@ -4693,7 +4693,7 @@
 			<key>uni1F34</key>
 			<integer>21</integer>
 			<key>uni1F35</key>
-			<integer>0</integer>
+			<integer>-50</integer>
 			<key>uni1F76</key>
 			<integer>-21</integer>
 			<key>uni1F77</key>
@@ -4701,7 +4701,7 @@
 			<key>uni1FD0</key>
 			<integer>-10</integer>
 			<key>uni1FD1</key>
-			<integer>0</integer>
+			<integer>-50</integer>
 			<key>uni1FD2</key>
 			<integer>84</integer>
 			<key>uni1FD3</key>
@@ -4849,7 +4849,7 @@
 			<key>uni1F35</key>
 			<integer>31</integer>
 			<key>uni1FD0</key>
-			<integer>0</integer>
+			<integer>-20</integer>
 			<key>uni1FD1</key>
 			<integer>10</integer>
 			<key>uni1FD2</key>
@@ -5287,7 +5287,7 @@
 			<key>uni1F33</key>
 			<integer>6</integer>
 			<key>uni1F34</key>
-			<integer>0</integer>
+			<integer>-10</integer>
 			<key>uni1FD2</key>
 			<integer>52</integer>
 			<key>uni1FD3</key>

--- a/source/Ubuntu-BI.ufo/kerning.plist
+++ b/source/Ubuntu-BI.ufo/kerning.plist
@@ -5149,7 +5149,7 @@
 			<key>uni1FD3</key>
 			<integer>52</integer>
 			<key>uni1FD6</key>
-			<integer>0</integer>
+			<integer>-70</integer>
 			<key>uni1FD7</key>
 			<integer>10</integer>
 			<key>uni1FE2</key>
@@ -5281,7 +5281,7 @@
 			<key>uni1F33</key>
 			<integer>41</integer>
 			<key>uni1F34</key>
-			<integer>0</integer>
+			<integer>-30</integer>
 			<key>uni1F35</key>
 			<integer>10</integer>
 			<key>uni1F76</key>
@@ -6142,7 +6142,7 @@
 			<key>uni1F35</key>
 			<integer>13</integer>
 			<key>uni1F76</key>
-			<integer>0</integer>
+			<integer>-35</integer>
 			<key>uni1FD0</key>
 			<integer>-7</integer>
 			<key>uni1FD1</key>

--- a/source/Ubuntu-C.ufo/kerning.plist
+++ b/source/Ubuntu-C.ufo/kerning.plist
@@ -12851,24 +12851,36 @@
 		</dict>
 		<key>public.kern1.MIS_uni01B3_FIRST</key>
 		<dict>
+			<key>adieresis</key>
+			<integer>-20</integer>
 			<key>aringacute</key>
 			<integer>-74</integer>
 			<key>ccaron</key>
 			<integer>-65</integer>
 			<key>ebreve</key>
 			<integer>-55</integer>
+			<key>edieresis</key>
+			<integer>-35</integer>
 			<key>emacron</key>
 			<integer>-55</integer>
 			<key>gbreve</key>
 			<integer>-75</integer>
 			<key>gcircumflex</key>
 			<integer>-85</integer>
+			<key>iacute</key>
+			<integer>-15</integer>
 			<key>ibreve</key>
-			<integer>30</integer>
-			<key>imacron</key>
-			<integer>40</integer>
-			<key>itilde</key>
+			<integer>10</integer>
+			<key>icircumflex</key>
+			<integer>10</integer>
+			<key>idieresis</key>
 			<integer>50</integer>
+			<key>igrave</key>
+			<integer>10</integer>
+			<key>imacron</key>
+			<integer>32</integer>
+			<key>itilde</key>
+			<integer>40</integer>
 			<key>jcircumflex</key>
 			<integer>30</integer>
 			<key>napostrophe</key>
@@ -12879,84 +12891,180 @@
 			<integer>-75</integer>
 			<key>omacron</key>
 			<integer>-65</integer>
+			<key>public.kern1.PUNCT_quotesingle</key>
+			<integer>20</integer>
+			<key>public.kern2.LAT_AE_UC_SECOND</key>
+			<integer>-70</integer>
+			<key>public.kern2.LAT_A_UC_SECOND</key>
+			<integer>-40</integer>
+			<key>public.kern2.LAT_C_UC_SECOND</key>
+			<integer>-25</integer>
+			<key>public.kern2.LAT_G_UC_SECOND</key>
+			<integer>-25</integer>
+			<key>public.kern2.LAT_J_UC_SECOND</key>
+			<integer>-65</integer>
+			<key>public.kern2.LAT_M_UC</key>
+			<integer>-20</integer>
+			<key>public.kern2.LAT_O_UC_SECOND</key>
+			<integer>-25</integer>
+			<key>public.kern2.LAT_Q_UC</key>
+			<integer>-25</integer>
+			<key>public.kern2.LAT_T_UC_SECOND</key>
+			<integer>35</integer>
 			<key>public.kern2.LAT_V_UC</key>
-			<integer>40</integer>
+			<integer>33</integer>
+			<key>public.kern2.LAT_W_UC</key>
+			<integer>23</integer>
+			<key>public.kern2.LAT_X_UC</key>
+			<integer>21</integer>
+			<key>public.kern2.LAT_Y_UC_SECOND</key>
+			<integer>35</integer>
+			<key>public.kern2.LAT_Z_UC_SECOND</key>
+			<integer>5</integer>
 			<key>public.kern2.LAT_a_LC_SECOND</key>
-			<integer>-84</integer>
+			<integer>-35</integer>
 			<key>public.kern2.LAT_c_LC_SECOND</key>
-			<integer>-95</integer>
+			<integer>-45</integer>
 			<key>public.kern2.LAT_d_LC_SECOND</key>
-			<integer>-95</integer>
+			<integer>-45</integer>
 			<key>public.kern2.LAT_e_LC_SECOND</key>
-			<integer>-95</integer>
+			<integer>-45</integer>
 			<key>public.kern2.LAT_eng_LC</key>
-			<integer>-80</integer>
+			<integer>-45</integer>
 			<key>public.kern2.LAT_eth_LC</key>
-			<integer>-95</integer>
+			<integer>-55</integer>
 			<key>public.kern2.LAT_g_LC_SECOND</key>
-			<integer>-95</integer>
+			<integer>-45</integer>
 			<key>public.kern2.LAT_n_LC_SECOND</key>
-			<integer>-80</integer>
+			<integer>-45</integer>
+			<key>public.kern2.LAT_napostroph.case_UC_SECOND</key>
+			<integer>50</integer>
 			<key>public.kern2.LAT_o_LC_SECOND</key>
-			<integer>-95</integer>
+			<integer>-45</integer>
 			<key>public.kern2.LAT_p_LC_SECOND</key>
-			<integer>-80</integer>
+			<integer>-45</integer>
 			<key>public.kern2.LAT_q_LC_SECOND</key>
-			<integer>-95</integer>
+			<integer>-45</integer>
 			<key>public.kern2.LAT_r_LC_SECOND</key>
-			<integer>-80</integer>
+			<integer>-45</integer>
 			<key>public.kern2.LAT_s_LC_SECOND</key>
-			<integer>-80</integer>
+			<integer>-35</integer>
 			<key>public.kern2.LAT_thorn_LC</key>
-			<integer>-80</integer>
+			<integer>-45</integer>
 			<key>public.kern2.LAT_u_LC_SECOND</key>
-			<integer>-76</integer>
+			<integer>-40</integer>
 			<key>public.kern2.LAT_v_LC_SECOND</key>
-			<integer>-48</integer>
+			<integer>-10</integer>
 			<key>public.kern2.LAT_w_LC_SECOND</key>
-			<integer>-40</integer>
+			<integer>-10</integer>
 			<key>public.kern2.LAT_x_LC</key>
-			<integer>-40</integer>
+			<integer>-15</integer>
 			<key>public.kern2.LAT_y_LC_SECOND</key>
-			<integer>-48</integer>
+			<integer>-10</integer>
 			<key>public.kern2.LAT_z_LC_SECOND</key>
-			<integer>-53</integer>
+			<integer>-20</integer>
 			<key>public.kern2.MIS_uni0181_SECOND</key>
-			<integer>44</integer>
+			<integer>20</integer>
 			<key>public.kern2.MIS_uni018D</key>
-			<integer>-95</integer>
+			<integer>-57</integer>
+			<key>public.kern2.MIS_uni0190</key>
+			<integer>-20</integer>
 			<key>public.kern2.MIS_uni019B</key>
-			<integer>29</integer>
+			<integer>40</integer>
+			<key>public.kern2.MIS_uni019C</key>
+			<integer>11</integer>
 			<key>public.kern2.MIS_uni01AA</key>
-			<integer>134</integer>
+			<integer>124</integer>
 			<key>public.kern2.MIS_uni01B7</key>
-			<integer>34</integer>
+			<integer>25</integer>
 			<key>public.kern2.MIS_uni01B8</key>
-			<integer>19</integer>
+			<integer>15</integer>
 			<key>public.kern2.MIS_uni01B9</key>
 			<integer>-62</integer>
 			<key>public.kern2.MIS_uni01BA</key>
-			<integer>-23</integer>
+			<integer>14</integer>
 			<key>public.kern2.MIS_uni01BB</key>
-			<integer>13</integer>
+			<integer>27</integer>
 			<key>public.kern2.MIS_uni01BC</key>
-			<integer>45</integer>
+			<integer>31</integer>
 			<key>public.kern2.MIS_uni01BD</key>
 			<integer>-35</integer>
 			<key>public.kern2.MIS_uni01BE</key>
-			<integer>20</integer>
+			<integer>25</integer>
 			<key>public.kern2.MIS_uni01BF</key>
-			<integer>-80</integer>
+			<integer>-45</integer>
+			<key>public.kern2.MIS_uni01DD_SECOND</key>
+			<integer>-35</integer>
 			<key>public.kern2.MIS_uni021C</key>
-			<integer>46</integer>
+			<integer>33</integer>
 			<key>public.kern2.MIS_uni021D</key>
-			<integer>-34</integer>
+			<integer>-6</integer>
+			<key>public.kern2.MIS_uni0234_SECOND</key>
+			<integer>-11</integer>
 			<key>public.kern2.MIS_uni0241</key>
 			<integer>36</integer>
 			<key>public.kern2.MIS_uni0242</key>
 			<integer>-41</integer>
 			<key>public.kern2.MIS_uni0292</key>
 			<integer>-40</integer>
+			<key>public.kern2.PUNCT_At</key>
+			<integer>-24</integer>
+			<key>public.kern2.PUNCT_Backslash</key>
+			<integer>30</integer>
+			<key>public.kern2.PUNCT_Braceleft</key>
+			<integer>-10</integer>
+			<key>public.kern2.PUNCT_Braceright</key>
+			<integer>20</integer>
+			<key>public.kern2.PUNCT_Bracketright</key>
+			<integer>10</integer>
+			<key>public.kern2.PUNCT_Guilsinglleft</key>
+			<integer>-21</integer>
+			<key>public.kern2.PUNCT_Guilsinglright</key>
+			<integer>-15</integer>
+			<key>public.kern2.PUNCT_Hyphen</key>
+			<integer>-40</integer>
+			<key>public.kern2.PUNCT_Parenleft</key>
+			<integer>-25</integer>
+			<key>public.kern2.PUNCT_Parenright</key>
+			<integer>18</integer>
+			<key>public.kern2.PUNCT_Slash</key>
+			<integer>-39</integer>
+			<key>public.kern2.PUNCT_ampersand</key>
+			<integer>-30</integer>
+			<key>public.kern2.PUNCT_asterisk</key>
+			<integer>10</integer>
+			<key>public.kern2.PUNCT_at</key>
+			<integer>-30</integer>
+			<key>public.kern2.PUNCT_backslash</key>
+			<integer>40</integer>
+			<key>public.kern2.PUNCT_braceleft</key>
+			<integer>-10</integer>
+			<key>public.kern2.PUNCT_braceright</key>
+			<integer>20</integer>
+			<key>public.kern2.PUNCT_bracketright</key>
+			<integer>10</integer>
+			<key>public.kern2.PUNCT_colon</key>
+			<integer>-10</integer>
+			<key>public.kern2.PUNCT_guilsinglleft</key>
+			<integer>-41</integer>
+			<key>public.kern2.PUNCT_guilsinglright</key>
+			<integer>-20</integer>
+			<key>public.kern2.PUNCT_hyphen</key>
+			<integer>-45</integer>
+			<key>public.kern2.PUNCT_parenleft</key>
+			<integer>-25</integer>
+			<key>public.kern2.PUNCT_parenright</key>
+			<integer>18</integer>
+			<key>public.kern2.PUNCT_period</key>
+			<integer>-40</integer>
+			<key>public.kern2.PUNCT_question</key>
+			<integer>25</integer>
+			<key>public.kern2.PUNCT_quoteleft</key>
+			<integer>20</integer>
+			<key>public.kern2.PUNCT_quoteright</key>
+			<integer>20</integer>
+			<key>public.kern2.PUNCT_slash</key>
+			<integer>-49</integer>
 			<key>rcaron</key>
 			<integer>-60</integer>
 			<key>scircumflex</key>
@@ -12982,19 +13090,23 @@
 			<key>uni01DC</key>
 			<integer>-46</integer>
 			<key>uni01DF</key>
-			<integer>-24</integer>
+			<integer>-25</integer>
+			<key>uni01F0</key>
+			<integer>15</integer>
 			<key>uni0201</key>
-			<integer>-14</integer>
+			<integer>-15</integer>
 			<key>uni0203</key>
 			<integer>-54</integer>
 			<key>uni0205</key>
-			<integer>-45</integer>
+			<integer>-25</integer>
 			<key>uni0207</key>
 			<integer>-65</integer>
 			<key>uni0209</key>
 			<integer>70</integer>
 			<key>uni020B</key>
-			<integer>40</integer>
+			<integer>30</integer>
+			<key>uni0211</key>
+			<integer>-20</integer>
 			<key>uni022B</key>
 			<integer>-45</integer>
 			<key>uni022D</key>

--- a/source/Ubuntu-L.ufo/kerning.plist
+++ b/source/Ubuntu-L.ufo/kerning.plist
@@ -4964,7 +4964,7 @@
 			<key>uni1F33</key>
 			<integer>83</integer>
 			<key>uni1F34</key>
-			<integer>0</integer>
+			<integer>-25</integer>
 			<key>uni1F35</key>
 			<integer>52</integer>
 			<key>uni1F36</key>

--- a/source/Ubuntu-LI.ufo/kerning.plist
+++ b/source/Ubuntu-LI.ufo/kerning.plist
@@ -4391,7 +4391,7 @@
 			<key>uni1FD3</key>
 			<integer>63</integer>
 			<key>uni1FD6</key>
-			<integer>0</integer>
+			<integer>-23</integer>
 			<key>uni1FD7</key>
 			<integer>11</integer>
 		</dict>
@@ -5022,7 +5022,7 @@
 			<key>uni1F37</key>
 			<integer>-43</integer>
 			<key>uni1F76</key>
-			<integer>0</integer>
+			<integer>-53</integer>
 			<key>uni1F77</key>
 			<integer>-10</integer>
 			<key>uni1FD0</key>

--- a/source/Ubuntu-M.ufo/kerning.plist
+++ b/source/Ubuntu-M.ufo/kerning.plist
@@ -4314,9 +4314,9 @@
 			<key>uni1F37</key>
 			<integer>-38</integer>
 			<key>uni1F76</key>
-			<integer>0</integer>
+			<integer>-82</integer>
 			<key>uni1F77</key>
-			<integer>0</integer>
+			<integer>-82</integer>
 			<key>uni1FD0</key>
 			<integer>25</integer>
 			<key>uni1FD1</key>
@@ -4828,7 +4828,7 @@
 			<key>uni1F33</key>
 			<integer>37</integer>
 			<key>uni1F35</key>
-			<integer>0</integer>
+			<integer>-15</integer>
 			<key>uni1FD2</key>
 			<integer>58</integer>
 			<key>uni1FD3</key>
@@ -5105,7 +5105,7 @@
 			<key>uni1F76</key>
 			<integer>12</integer>
 			<key>uni1F77</key>
-			<integer>0</integer>
+			<integer>-69</integer>
 			<key>uni1FD0</key>
 			<integer>25</integer>
 			<key>uni1FD1</key>

--- a/source/Ubuntu-MI.ufo/kerning.plist
+++ b/source/Ubuntu-MI.ufo/kerning.plist
@@ -3783,7 +3783,7 @@
 			<key>uni1F35</key>
 			<integer>-2</integer>
 			<key>uni1FD1</key>
-			<integer>0</integer>
+			<integer>-22</integer>
 			<key>uni1FD2</key>
 			<integer>55</integer>
 			<key>uni1FD3</key>
@@ -4808,11 +4808,11 @@
 			<key>uni1F36</key>
 			<integer>-43</integer>
 			<key>uni1F76</key>
-			<integer>0</integer>
+			<integer>-53</integer>
 			<key>uni1F77</key>
 			<integer>-25</integer>
 			<key>uni1FD0</key>
-			<integer>0</integer>
+			<integer>-53</integer>
 			<key>uni1FD1</key>
 			<integer>25</integer>
 			<key>uni1FD2</key>

--- a/tools/postprocess-kern.py
+++ b/tools/postprocess-kern.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+#
+# In the Google Fonts release, the GPOS and legacy kern table disagree on
+# various kernings, especially in C. We treat the GPOS table as the canonical
+# one (it's what modern layout libraries use) and simply patch the legacy kern
+# table in the generated binaries.
+
+
+import os
+import sys
+import argparse
+import fontTools.ttLib
+
+parser = argparse.ArgumentParser()
+parser.add_argument("ttf", type=str, help="The path to the input TTF.")
+args = parser.parse_args()
+
+ttf = fontTools.ttLib.TTFont(args.ttf)
+
+if not "kern" in ttf:
+    sys.exit(0)
+
+kt = ttf["kern"].kernTables[0].kernTable
+
+if "Ubuntu-M.ttf" in args.ttf:
+    del kt[('Gamma', 'uni1F76')]
+    del kt[('Gamma', 'uni1F77')]
+    del kt[('Tau', 'uni1F77')]
+    del kt[('Psi', 'uni1F35')]
+elif "Ubuntu-MI.ttf" in args.ttf:
+    kt[('Gamma', 'uni1F76')] = -12
+    kt[('Gamma', 'uni1F77')] = -17
+    del kt[('Tau', 'uni1F76')]
+    kt[('Tau', 'uni1F77')] = -25
+    del kt[('Tau', 'uni1FD0')]
+    del kt[('Chi', 'uni1FD1')]
+elif "Ubuntu-L.ttf" in args.ttf:
+    del kt[('Upsilon', 'uni1F34')]
+elif "Ubuntu-LI.ttf" in args.ttf:
+    del kt[('Kappa', 'uni1FD6')]
+    del kt[('Tau', 'uni1F76')]
+    kt[('Upsilon', 'uni1F34')] = 52
+elif "Ubuntu-C.ttf" in args.ttf:
+    del kt[('uni01B3', 'ampersand')]
+    del kt[('uni01B3', 'quotesingle')]
+    del kt[('uni01B3', 'parenleft')]
+    del kt[('uni01B3', 'parenright')]
+    del kt[('uni01B3', 'asterisk')]
+    del kt[('uni01B3', 'hyphen')]
+    del kt[('uni01B3', 'period')]
+    del kt[('uni01B3', 'slash')]
+    del kt[('uni01B3', 'colon')]
+    del kt[('uni01B3', 'question')]
+    del kt[('uni01B3', 'at')]
+    del kt[('uni01B3', 'A')]
+    del kt[('uni01B3', 'C')]
+    del kt[('uni01B3', 'G')]
+    del kt[('uni01B3', 'J')]
+    del kt[('uni01B3', 'M')]
+    del kt[('uni01B3', 'O')]
+    del kt[('uni01B3', 'Q')]
+    del kt[('uni01B3', 'T')]
+    kt[('uni01B3', 'V')] = 40
+    del kt[('uni01B3', 'W')]
+    del kt[('uni01B3', 'X')]
+    del kt[('uni01B3', 'Y')]
+    del kt[('uni01B3', 'Z')]
+    del kt[('uni01B3', 'backslash')]
+    del kt[('uni01B3', 'bracketright')]
+    kt[('uni01B3', 'a')] = -84
+    kt[('uni01B3', 'c')] = -95
+    kt[('uni01B3', 'd')] = -95
+    kt[('uni01B3', 'e')] = -95
+    kt[('uni01B3', 'g')] = -95
+    kt[('uni01B3', 'n')] = -80
+    kt[('uni01B3', 'o')] = -95
+    kt[('uni01B3', 'p')] = -80
+    kt[('uni01B3', 'q')] = -95
+    kt[('uni01B3', 'r')] = -80
+    kt[('uni01B3', 's')] = -80
+    kt[('uni01B3', 'u')] = -76
+    kt[('uni01B3', 'v')] = -48
+    kt[('uni01B3', 'w')] = -40
+    kt[('uni01B3', 'x')] = -40
+    kt[('uni01B3', 'y')] = -48
+    kt[('uni01B3', 'z')] = -53
+    del kt[('uni01B3', 'braceleft')]
+    del kt[('uni01B3', 'braceright')]
+    del kt[('uni01B3', 'guilsinglleft')]
+    del kt[('uni01B3', 'quoteleft')]
+    del kt[('uni01B3', 'quoteright')]
+    del kt[('uni01B3', 'guilsinglright')]
+    del kt[('uni01B3', 'AE')]
+    del kt[('uni01B3', 'adieresis')]
+    del kt[('uni01B3', 'edieresis')]
+    del kt[('uni01B3', 'igrave')]
+    del kt[('uni01B3', 'iacute')]
+    del kt[('uni01B3', 'icircumflex')]
+    del kt[('uni01B3', 'idieresis')]
+    kt[('uni01B3', 'eth')] = -95
+    kt[('uni01B3', 'thorn')] = -80
+    kt[('uni01B3', 'itilde')] = 50
+    kt[('uni01B3', 'imacron')] = 40
+    kt[('uni01B3', 'ibreve')] = 30
+    del kt[('uni01B3', 'napostrophe.case')]
+    kt[('uni01B3', 'eng')] = -80
+    del kt[('uni01B3', 'Parenleft')]
+    del kt[('uni01B3', 'Parenright')]
+    del kt[('uni01B3', 'Hyphen')]
+    del kt[('uni01B3', 'Slash')]
+    del kt[('uni01B3', 'At')]
+    del kt[('uni01B3', 'Backslash')]
+    del kt[('uni01B3', 'Bracketright')]
+    del kt[('uni01B3', 'Braceleft')]
+    del kt[('uni01B3', 'Braceright')]
+    del kt[('uni01B3', 'Guilsinglleft')]
+    del kt[('uni01B3', 'Guilsinglright')]
+    kt[('uni01B3', 'uni0181')] = 44
+    kt[('uni01B3', 'uni018D')] = -95
+    del kt[('uni01B3', 'uni0190')]
+    kt[('uni01B3', 'uni019B')] = 29
+    del kt[('uni01B3', 'uni019C')]
+    kt[('uni01B3', 'uni01AA')] = 134
+    kt[('uni01B3', 'uni01B7')] = 34
+    kt[('uni01B3', 'uni01B8')] = 19
+    kt[('uni01B3', 'uni01BA')] = -23
+    kt[('uni01B3', 'uni01BB')] = 13
+    kt[('uni01B3', 'uni01BC')] = 45
+    kt[('uni01B3', 'uni01BE')] = 20
+    kt[('uni01B3', 'uni01BF')] = -80
+    del kt[('uni01B3', 'uni01DD')]
+    kt[('uni01B3', 'uni01DF')] = -24
+    del kt[('uni01B3', 'uni01F0')]
+    kt[('uni01B3', 'uni0201')] = -14
+    kt[('uni01B3', 'uni0205')] = -45
+    kt[('uni01B3', 'uni020B')] = 40
+    del kt[('uni01B3', 'uni0211')]
+    kt[('uni01B3', 'uni021C')] = 46
+    kt[('uni01B3', 'uni021D')] = -34
+    del kt[('uni01B3', 'uni0234')]
+elif "Ubuntu-B.ttf" in args.ttf:
+    del kt[('Gamma', 'uni1F35')]
+    del kt[('Gamma', 'uni1FD1')]
+    del kt[('Kappa', 'uni1FD0')]
+    del kt[('Psi', 'uni1F34')]
+elif "Ubuntu-BI.ttf" in args.ttf:
+    kt[('Gamma', 'uni1F35')] = 1
+    kt[('Gamma', 'uni1FD1')] = 10
+    del kt[('Gamma', 'uni1FD6')]
+    del kt[('Kappa', 'uni1F34')]
+    kt[('Kappa', 'uni1FD0')] = -10
+    del kt[('Upsilon', 'uni1F76')]
+
+ttf.save(args.ttf)


### PR DESCRIPTION
1. Match GPOS kerning to GF release (validated with https://github.com/adobe-type-tools/kern-dump). Note that the UFO sources declare the language systems differently, but none of them change the features, so I suppose it makes no difference.
2. Match kern table to GF release.

The GPOS table is the canonical one, the kern table is simply post-processed.

To validate, use this script (modify the paths and rename the GF download to match the file names of the UFO sources; on macOS, remove the `sed` line and the `-u` parameter from `cp`):
```Bash
#!/bin/env bash

REMOVE_LINES="/\(created\|modified\|Revision\|checkSum\|version\|xAvgCharWidth\)/d"

mkdir -p /tmp/font1
cp -u PATH/TO/GF/DOWNLOAD/*ttf /tmp/font1
rm /tmp/font1/*ttx
for f in /tmp/font1/*ttf; do
  ttx -t "$1" $f
  sed -i $REMOVE_LINES ${f/ttf/ttx}
done

mkdir -p /tmp/font2
cp -u PATH/TO/REPO/build/*ttf /tmp/font2
rm /tmp/font2/*ttx
for f in /tmp/font2/*ttf; do
  ttx -t "$1" $f
  sed -i $REMOVE_LINES ${f/ttf/ttx}
done

for f in /tmp/font1/*ttx; do
  diff -U2 $f ${f/font1/font2}
done
```
```
# Build UFO sources first.
$ bash above_script.sh kern
$ dumpkerning.py /tmp/font1/*ttf /tmp/font2/*ttf
$ for f in /tmp/font1/*kerndump; do diff -U2 $f ${f/font1/font2}; done
```
You should see no diffs.