### PR TITLE
Gsub fixes

### DIFF
--- a/source/Ubuntu-B.ufo/features.fea
+++ b/source/Ubuntu-B.ufo/features.fea
@@ -27,12 +27,15 @@
 @OmegaSub = [uni1FA8 uni1FA9 uni1FAA uni1FAB uni1FAC uni1FAD uni1FAE uni1FAF uni1FFC];
 @OmegaSub.alt = [uni1FA8.alt uni1FA9.alt uni1FAA.alt uni1FAB.alt uni1FAC.alt uni1FAD.alt uni1FAE.alt uni1FAF.alt uni1FFC.alt];
 
-# languagesystem DFLT dflt;
+languagesystem DFLT dflt;
 languagesystem latn dflt;
 languagesystem latn AZE;
 languagesystem latn CRT;
+languagesystem latn MOL;
+languagesystem latn ROM;
 languagesystem latn TRK;
 languagesystem cyrl dflt;
+languagesystem cyrl BGR;
 languagesystem cyrl MKD;
 languagesystem cyrl SRB;
 languagesystem grek dflt;
@@ -182,19 +185,37 @@ lookup salt03 {
 } salt03;
 
 feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature pnum {
@@ -204,6 +225,8 @@ feature pnum {
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup pnum_text;
@@ -211,6 +234,7 @@ feature pnum {
 	lookup pnum_text;
  	language SRB; # Serbian
  	language MKD; # Macedonian
+	language BGR;
 } pnum;
 
 feature tnum {
@@ -219,11 +243,14 @@ feature tnum {
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup tnum_text;
 	script cyrl; # Cyrillic
 	lookup tnum_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } tnum;
@@ -234,12 +261,15 @@ feature numr { # Numerators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup numr_text;
 
 	script cyrl; # Cyrillic
 	lookup numr_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } numr;
@@ -247,17 +277,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -266,12 +285,15 @@ feature dnom { # Denominators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup dnom_text;
 
 	script cyrl; # Cyrillic
 	lookup dnom_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } dnom;
@@ -282,12 +304,15 @@ feature sups { # Superscript
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sups_text;
 
 	script cyrl; # Cyrillic
 	lookup sups_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } sups;
@@ -298,12 +323,15 @@ feature subs { # Subscripts
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sub1;
 
 	script cyrl; # Cyrillic
 	lookup sub1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } subs;
@@ -314,15 +342,17 @@ feature sinf { # Scientific Inferiors
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sin1;
 
 	script cyrl; # Cyrillic
 	lookup sin1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
-
 } sinf;
 
 feature frac { # Fractions
@@ -334,12 +364,17 @@ feature frac { # Fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
 	lookup frac12;
 	lookup frac13;
 	lookup frac14;
 	lookup frac15;
+	language BGR;
+	language MKD;
+	language SRB;
 
 	script grek;
 	lookup frac12;
@@ -353,13 +388,16 @@ feature case { # Case-Sensitive Forms
   script latn;
   lookup case_add;
   lookup case_dflt;
-  language AZE;
-  language TRK;
-  language CRT;
+	language AZE;
+	language TRK;
+	language CRT;
 
   script cyrl;
   lookup case_add;
   lookup case_dflt;
+	language BGR;
+	language MKD;
+	language SRB;
 
   script grek;
   lookup case_add;
@@ -367,20 +405,54 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature liga { # Standard Ligatures
-	script latn;
-	lookup ligatures;
-	language AZE;
-	language TRK;
-	language CRT;
+script cyrl;
+      language dflt;
+      lookup liga_cyrl_dflt_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_cyrl_dflt_1;
 
-	script cyrl;
-	lookup ligatures;
+      script grek;
+      language dflt;
+      lookup liga_grek_dflt_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_grek_dflt_1;
 
-	script grek;
-	lookup ligatures;
+      script latn;
+      language AZE;
+      lookup liga_latn_AZE_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_latn_AZE_1;
+
+      language CRT ;
+      lookup liga_latn_AZE_1;
+      language MOL ;
+      lookup liga_latn_AZE_1;
+      language ROM ;
+      lookup liga_latn_AZE_1;
+      language TRK ;
+      lookup liga_latn_AZE_1;
+      language dflt;
+      lookup liga_latn_AZE_1;
 } liga;
 
 feature ss01 { # Greek Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;
@@ -388,6 +460,11 @@ feature ss01 { # Greek Stylistic Alternates
 } ss01;
 
 feature salt { # Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;

--- a/source/Ubuntu-BI.ufo/features.fea
+++ b/source/Ubuntu-BI.ufo/features.fea
@@ -27,12 +27,13 @@
 @OmegaSub = [uni1FA8 uni1FA9 uni1FAA uni1FAB uni1FAC uni1FAD uni1FAE uni1FAF uni1FFC];
 @OmegaSub.alt = [uni1FA8.alt uni1FA9.alt uni1FAA.alt uni1FAB.alt uni1FAC.alt uni1FAD.alt uni1FAE.alt uni1FAF.alt uni1FFC.alt];
 
-# languagesystem DFLT dflt;
+languagesystem DFLT dflt;
 languagesystem latn dflt;
 languagesystem latn AZE;
 languagesystem latn CRT;
 languagesystem latn TRK;
 languagesystem cyrl dflt;
+languagesystem cyrl BGR;
 languagesystem cyrl MKD;
 languagesystem cyrl SRB;
 languagesystem grek dflt;
@@ -185,20 +186,50 @@ lookup salt03 {
 	sub @OmegaSub by @OmegaSub.alt;
 } salt03;
 
-feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+lookup salt04 {
+	sub ampersand by ampersand.001;
+} salt04;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+feature locl { # Localized Forms
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
+
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature pnum {
@@ -251,17 +282,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -338,8 +358,21 @@ feature frac { # Fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
+	language MKD;
+	lookup frac12;
+	lookup frac13;
+	lookup frac14;
+	lookup frac15;
+	language SRB;
+	lookup frac12;
+	lookup frac13;
+	lookup frac14;
+	lookup frac15;
+	language dflt;
 	lookup frac12;
 	lookup frac13;
 	lookup frac14;
@@ -364,6 +397,9 @@ feature case { # Case-Sensitive Forms
   script cyrl;
   lookup case_add;
   lookup case_dflt;
+	language BGR;
+	language MKD;
+	language SRB;
 
   script grek;
   lookup case_add;
@@ -371,17 +407,47 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature liga { # Standard Ligatures
-	script latn;
-	lookup ligatures;
-	language AZE;
-	language TRK;
-	language CRT;
-
 	script cyrl;
-	lookup ligatures;
+	language MKD ;
+	lookup liga_cyrl_MKD_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_cyrl_MKD_1;
+
+	language SRB ;
+	lookup liga_cyrl_MKD_1;
+	language dflt;
+	lookup liga_cyrl_MKD_1;
 
 	script grek;
-	lookup ligatures;
+	language dflt;
+	lookup liga_grek_dflt_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_grek_dflt_1;
+
+	script latn;
+	language AZE;
+	lookup liga_latn_AZE_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_latn_AZE_1;
+
+	language CRT ;
+	lookup liga_latn_AZE_1;
+	language TRK ;
+	lookup liga_latn_AZE_1;
+	language dflt;
+	lookup liga_latn_AZE_1;
 } liga;
 
 feature ss01 { # Greek Stylistic Alternates
@@ -389,10 +455,20 @@ feature ss01 { # Greek Stylistic Alternates
 	lookup salt01;
 	lookup salt02;
 	lookup salt03;
+
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
 } ss01;
 
 feature salt { # Stylistic Alternates
 	script grek; # Greek
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
+	script latn;
 	lookup salt01;
 	lookup salt02;
 	lookup salt03;

--- a/source/Ubuntu-C.ufo/features.fea
+++ b/source/Ubuntu-C.ufo/features.fea
@@ -27,12 +27,15 @@
 @OmegaSub = [uni1FA8 uni1FA9 uni1FAA uni1FAB uni1FAC uni1FAD uni1FAE uni1FAF uni1FFC];
 @OmegaSub.alt = [uni1FA8.alt uni1FA9.alt uni1FAA.alt uni1FAB.alt uni1FAC.alt uni1FAD.alt uni1FAE.alt uni1FAF.alt uni1FFC.alt];
 
-# languagesystem DFLT dflt;
+languagesystem DFLT dflt;
 languagesystem latn dflt;
 languagesystem latn AZE;
 languagesystem latn CRT;
+languagesystem latn MOL;
+languagesystem latn ROM;
 languagesystem latn TRK;
 languagesystem cyrl dflt;
+languagesystem cyrl BGR;
 languagesystem cyrl MKD;
 languagesystem cyrl SRB;
 languagesystem grek dflt;
@@ -182,19 +185,37 @@ lookup salt03 {
 } salt03;
 
 feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature pnum {
@@ -204,6 +225,8 @@ feature pnum {
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup pnum_text;
@@ -211,6 +234,7 @@ feature pnum {
 	lookup pnum_text;
  	language SRB; # Serbian
  	language MKD; # Macedonian
+	language BGR;
 } pnum;
 
 feature tnum {
@@ -219,11 +243,14 @@ feature tnum {
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup tnum_text;
 	script cyrl; # Cyrillic
 	lookup tnum_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } tnum;
@@ -234,12 +261,15 @@ feature numr { # Numerators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup numr_text;
 
 	script cyrl; # Cyrillic
 	lookup numr_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } numr;
@@ -247,17 +277,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -266,12 +285,15 @@ feature dnom { # Denominators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup dnom_text;
 
 	script cyrl; # Cyrillic
 	lookup dnom_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } dnom;
@@ -282,12 +304,15 @@ feature sups { # Superscript
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sups_text;
 
 	script cyrl; # Cyrillic
 	lookup sups_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } sups;
@@ -298,12 +323,15 @@ feature subs { # Subscripts
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sub1;
 
 	script cyrl; # Cyrillic
 	lookup sub1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } subs;
@@ -314,15 +342,17 @@ feature sinf { # Scientific Inferiors
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sin1;
 
 	script cyrl; # Cyrillic
 	lookup sin1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
-
 } sinf;
 
 feature frac { # Fractions
@@ -334,12 +364,17 @@ feature frac { # Fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
 	lookup frac12;
 	lookup frac13;
 	lookup frac14;
 	lookup frac15;
+	language BGR;
+	language MKD;
+	language SRB;
 
 	script grek;
 	lookup frac12;
@@ -353,13 +388,18 @@ feature case { # Case-Sensitive Forms
   script latn;
   lookup case_add;
   lookup case_dflt;
-  language AZE;
-  language TRK;
-  language CRT;
+	language AZE;
+	language TRK;
+	language CRT;
+	language MOL;
+	language ROM;
 
   script cyrl;
   lookup case_add;
   lookup case_dflt;
+	language BGR;
+	language MKD;
+	language SRB;
 
   script grek;
   lookup case_add;
@@ -367,20 +407,54 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature liga { # Standard Ligatures
-	script latn;
-	lookup ligatures;
-	language AZE;
-	language TRK;
-	language CRT;
+script cyrl;
+      language dflt;
+      lookup liga_cyrl_dflt_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_cyrl_dflt_1;
 
-	script cyrl;
-	lookup ligatures;
+      script grek;
+      language dflt;
+      lookup liga_grek_dflt_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_grek_dflt_1;
 
-	script grek;
-	lookup ligatures;
+      script latn;
+      language AZE;
+      lookup liga_latn_AZE_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_latn_AZE_1;
+
+      language CRT ;
+      lookup liga_latn_AZE_1;
+      language MOL ;
+      lookup liga_latn_AZE_1;
+      language ROM ;
+      lookup liga_latn_AZE_1;
+      language TRK ;
+      lookup liga_latn_AZE_1;
+      language dflt;
+      lookup liga_latn_AZE_1;
 } liga;
 
 feature ss01 { # Greek Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;
@@ -388,6 +462,11 @@ feature ss01 { # Greek Stylistic Alternates
 } ss01;
 
 feature salt { # Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;

--- a/source/Ubuntu-L.ufo/features.fea
+++ b/source/Ubuntu-L.ufo/features.fea
@@ -27,12 +27,13 @@
 @OmegaSub = [uni1FA8 uni1FA9 uni1FAA uni1FAB uni1FAC uni1FAD uni1FAE uni1FAF uni1FFC];
 @OmegaSub.alt = [uni1FA8.alt uni1FA9.alt uni1FAA.alt uni1FAB.alt uni1FAC.alt uni1FAD.alt uni1FAE.alt uni1FAF.alt uni1FFC.alt];
 
-# languagesystem DFLT dflt;
+languagesystem DFLT dflt;
 languagesystem latn dflt;
 languagesystem latn AZE;
 languagesystem latn CRT;
 languagesystem latn TRK;
 languagesystem cyrl dflt;
+languagesystem cyrl BGR;
 languagesystem cyrl MKD;
 languagesystem cyrl SRB;
 languagesystem grek dflt;
@@ -182,19 +183,37 @@ lookup salt03 {
 } salt03;
 
 feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature pnum {
@@ -211,6 +230,7 @@ feature pnum {
 	lookup pnum_text;
  	language SRB; # Serbian
  	language MKD; # Macedonian
+	language BGR;
 } pnum;
 
 feature tnum {
@@ -224,6 +244,7 @@ feature tnum {
 	lookup tnum_text;
 	script cyrl; # Cyrillic
 	lookup tnum_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } tnum;
@@ -240,6 +261,7 @@ feature numr { # Numerators
 
 	script cyrl; # Cyrillic
 	lookup numr_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } numr;
@@ -247,17 +269,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -272,6 +283,7 @@ feature dnom { # Denominators
 
 	script cyrl; # Cyrillic
 	lookup dnom_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } dnom;
@@ -288,6 +300,7 @@ feature sups { # Superscript
 
 	script cyrl; # Cyrillic
 	lookup sups_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } sups;
@@ -304,6 +317,7 @@ feature subs { # Subscripts
 
 	script cyrl; # Cyrillic
 	lookup sub1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } subs;
@@ -320,9 +334,9 @@ feature sinf { # Scientific Inferiors
 
 	script cyrl; # Cyrillic
 	lookup sin1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
-
 } sinf;
 
 feature frac { # Fractions
@@ -340,6 +354,9 @@ feature frac { # Fractions
 	lookup frac13;
 	lookup frac14;
 	lookup frac15;
+	language BGR;
+	language MKD;
+	language SRB;
 
 	script grek;
 	lookup frac12;
@@ -353,13 +370,16 @@ feature case { # Case-Sensitive Forms
   script latn;
   lookup case_add;
   lookup case_dflt;
-  language AZE;
-  language TRK;
-  language CRT;
+	language AZE;
+	language TRK;
+	language CRT;
 
   script cyrl;
   lookup case_add;
   lookup case_dflt;
+	language BGR;
+	language MKD;
+	language SRB;
 
   script grek;
   lookup case_add;
@@ -367,20 +387,50 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature liga { # Standard Ligatures
-	script latn;
-	lookup ligatures;
-	language AZE;
-	language TRK;
-	language CRT;
+script cyrl;
+      language dflt;
+      lookup liga_cyrl_dflt_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_cyrl_dflt_1;
 
-	script cyrl;
-	lookup ligatures;
+      script grek;
+      language dflt;
+      lookup liga_grek_dflt_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_grek_dflt_1;
 
-	script grek;
-	lookup ligatures;
+      script latn;
+      language AZE;
+      lookup liga_latn_AZE_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_latn_AZE_1;
+
+      language CRT ;
+      lookup liga_latn_AZE_1;
+      language TRK ;
+      lookup liga_latn_AZE_1;
+      language dflt;
+      lookup liga_latn_AZE_1;
 } liga;
 
 feature ss01 { # Greek Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;
@@ -388,6 +438,11 @@ feature ss01 { # Greek Stylistic Alternates
 } ss01;
 
 feature salt { # Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;

--- a/source/Ubuntu-LI.ufo/features.fea
+++ b/source/Ubuntu-LI.ufo/features.fea
@@ -27,12 +27,13 @@
 @OmegaSub = [uni1FA8 uni1FA9 uni1FAA uni1FAB uni1FAC uni1FAD uni1FAE uni1FAF uni1FFC];
 @OmegaSub.alt = [uni1FA8.alt uni1FA9.alt uni1FAA.alt uni1FAB.alt uni1FAC.alt uni1FAD.alt uni1FAE.alt uni1FAF.alt uni1FFC.alt];
 
-# languagesystem DFLT dflt;
+languagesystem DFLT dflt;
 languagesystem latn dflt;
 languagesystem latn AZE;
 languagesystem latn CRT;
 languagesystem latn TRK;
 languagesystem cyrl dflt;
+languagesystem cyrl BGR;
 languagesystem cyrl MKD;
 languagesystem cyrl SRB;
 languagesystem grek dflt;
@@ -185,20 +186,50 @@ lookup salt03 {
 	sub @OmegaSub by @OmegaSub.alt;
 } salt03;
 
-feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+lookup salt04 {
+	sub ampersand by ampersand.001;
+} salt04;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+feature locl { # Localized Forms
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
+
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature pnum {
@@ -208,6 +239,8 @@ feature pnum {
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup pnum_text;
@@ -223,6 +256,8 @@ feature tnum {
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup tnum_text;
@@ -238,6 +273,8 @@ feature numr { # Numerators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup numr_text;
@@ -251,17 +288,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -270,6 +296,8 @@ feature dnom { # Denominators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup dnom_text;
@@ -286,6 +314,8 @@ feature sups { # Superscript
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sups_text;
@@ -302,6 +332,8 @@ feature subs { # Subscripts
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sub1;
@@ -318,6 +350,8 @@ feature sinf { # Scientific Inferiors
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup sin1;
@@ -338,8 +372,21 @@ feature frac { # Fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
+	language MKD;
+	lookup frac12;
+	lookup frac13;
+	lookup frac14;
+	lookup frac15;
+	language SRB;
+	lookup frac12;
+	lookup frac13;
+	lookup frac14;
+	lookup frac15;
+	language dflt;
 	lookup frac12;
 	lookup frac13;
 	lookup frac14;
@@ -364,6 +411,9 @@ feature case { # Case-Sensitive Forms
   script cyrl;
   lookup case_add;
   lookup case_dflt;
+	language BGR;
+	language MKD;
+	language SRB;
 
   script grek;
   lookup case_add;
@@ -371,17 +421,51 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature liga { # Standard Ligatures
-	script latn;
-	lookup ligatures;
-	language AZE;
-	language TRK;
-	language CRT;
-
 	script cyrl;
-	lookup ligatures;
+	language MKD ;
+	lookup liga_cyrl_MKD_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_cyrl_MKD_1;
+
+	language SRB ;
+	lookup liga_cyrl_MKD_1;
+	language dflt;
+	lookup liga_cyrl_MKD_1;
 
 	script grek;
-	lookup ligatures;
+	language dflt;
+	lookup liga_grek_dflt_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_grek_dflt_1;
+
+	script latn;
+	language AZE;
+	lookup liga_latn_AZE_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_latn_AZE_1;
+
+	language CRT ;
+	lookup liga_latn_AZE_1;
+	language MOL ;
+	lookup liga_latn_AZE_1;
+	language ROM ;
+	lookup liga_latn_AZE_1;
+	language TRK ;
+	lookup liga_latn_AZE_1;
+	language dflt;
+	lookup liga_latn_AZE_1;
 } liga;
 
 feature ss01 { # Greek Stylistic Alternates
@@ -389,10 +473,28 @@ feature ss01 { # Greek Stylistic Alternates
 	lookup salt01;
 	lookup salt02;
 	lookup salt03;
+
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
 } ss01;
+
+feature ss02 {
+  script latn;
+  language dflt;
+  lookup ss02_latn_dflt_1 {
+    sub ampersand by ampersand.001;
+  } ss02_latn_dflt_1;
+} ss02;
 
 feature salt { # Stylistic Alternates
 	script grek; # Greek
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
+	script latn;
 	lookup salt01;
 	lookup salt02;
 	lookup salt03;

--- a/source/Ubuntu-M.ufo/features.fea
+++ b/source/Ubuntu-M.ufo/features.fea
@@ -27,12 +27,15 @@
 @OmegaSub = [uni1FA8 uni1FA9 uni1FAA uni1FAB uni1FAC uni1FAD uni1FAE uni1FAF uni1FFC];
 @OmegaSub.alt = [uni1FA8.alt uni1FA9.alt uni1FAA.alt uni1FAB.alt uni1FAC.alt uni1FAD.alt uni1FAE.alt uni1FAF.alt uni1FFC.alt];
 
-# languagesystem DFLT dflt;
+languagesystem DFLT dflt;
 languagesystem latn dflt;
 languagesystem latn AZE;
 languagesystem latn CRT;
+languagesystem latn MOL;
+languagesystem latn ROM;
 languagesystem latn TRK;
 languagesystem cyrl dflt;
+languagesystem cyrl BGR;
 languagesystem cyrl MKD;
 languagesystem cyrl SRB;
 languagesystem grek dflt;
@@ -182,19 +185,37 @@ lookup salt03 {
 } salt03;
 
 feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature pnum {
@@ -204,6 +225,8 @@ feature pnum {
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup pnum_text;
@@ -211,6 +234,7 @@ feature pnum {
 	lookup pnum_text;
  	language SRB; # Serbian
  	language MKD; # Macedonian
+	language BGR;
 } pnum;
 
 feature tnum {
@@ -219,11 +243,14 @@ feature tnum {
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup tnum_text;
 	script cyrl; # Cyrillic
 	lookup tnum_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } tnum;
@@ -234,12 +261,15 @@ feature numr { # Numerators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup numr_text;
 
 	script cyrl; # Cyrillic
 	lookup numr_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } numr;
@@ -247,17 +277,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -266,12 +285,15 @@ feature dnom { # Denominators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup dnom_text;
 
 	script cyrl; # Cyrillic
 	lookup dnom_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } dnom;
@@ -282,12 +304,15 @@ feature sups { # Superscript
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sups_text;
 
 	script cyrl; # Cyrillic
 	lookup sups_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } sups;
@@ -298,12 +323,15 @@ feature subs { # Subscripts
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sub1;
 
 	script cyrl; # Cyrillic
 	lookup sub1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } subs;
@@ -314,15 +342,17 @@ feature sinf { # Scientific Inferiors
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sin1;
 
 	script cyrl; # Cyrillic
 	lookup sin1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
-
 } sinf;
 
 feature frac { # Fractions
@@ -334,12 +364,17 @@ feature frac { # Fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
 	lookup frac12;
 	lookup frac13;
 	lookup frac14;
 	lookup frac15;
+	language BGR;
+	language MKD;
+	language SRB;
 
 	script grek;
 	lookup frac12;
@@ -353,13 +388,16 @@ feature case { # Case-Sensitive Forms
   script latn;
   lookup case_add;
   lookup case_dflt;
-  language AZE;
-  language TRK;
-  language CRT;
+	language AZE;
+	language TRK;
+	language CRT;
 
   script cyrl;
   lookup case_add;
   lookup case_dflt;
+	language BGR;
+	language MKD;
+	language SRB;
 
   script grek;
   lookup case_add;
@@ -367,20 +405,54 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature liga { # Standard Ligatures
-	script latn;
-	lookup ligatures;
-	language AZE;
-	language TRK;
-	language CRT;
+script cyrl;
+      language dflt;
+      lookup liga_cyrl_dflt_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_cyrl_dflt_1;
 
-	script cyrl;
-	lookup ligatures;
+      script grek;
+      language dflt;
+      lookup liga_grek_dflt_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_grek_dflt_1;
 
-	script grek;
-	lookup ligatures;
+      script latn;
+      language AZE;
+      lookup liga_latn_AZE_1 {
+        sub f f by f_f;
+        sub f f i by f_f_i;
+        sub f f l by f_f_l;
+        sub f i by f_i;
+        sub f l by f_l;
+      } liga_latn_AZE_1;
+
+      language CRT ;
+      lookup liga_latn_AZE_1;
+      language MOL ;
+      lookup liga_latn_AZE_1;
+      language ROM ;
+      lookup liga_latn_AZE_1;
+      language TRK ;
+      lookup liga_latn_AZE_1;
+      language dflt;
+      lookup liga_latn_AZE_1;
 } liga;
 
 feature ss01 { # Greek Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;
@@ -388,6 +460,11 @@ feature ss01 { # Greek Stylistic Alternates
 } ss01;
 
 feature salt { # Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;

--- a/source/Ubuntu-MI.ufo/features.fea
+++ b/source/Ubuntu-MI.ufo/features.fea
@@ -27,12 +27,13 @@
 @OmegaSub = [uni1FA8 uni1FA9 uni1FAA uni1FAB uni1FAC uni1FAD uni1FAE uni1FAF uni1FFC];
 @OmegaSub.alt = [uni1FA8.alt uni1FA9.alt uni1FAA.alt uni1FAB.alt uni1FAC.alt uni1FAD.alt uni1FAE.alt uni1FAF.alt uni1FFC.alt];
 
-# languagesystem DFLT dflt;
+languagesystem DFLT dflt;
 languagesystem latn dflt;
 languagesystem latn AZE;
 languagesystem latn CRT;
 languagesystem latn TRK;
 languagesystem cyrl dflt;
+languagesystem cyrl BGR;
 languagesystem cyrl MKD;
 languagesystem cyrl SRB;
 languagesystem grek dflt;
@@ -185,20 +186,50 @@ lookup salt03 {
 	sub @OmegaSub by @OmegaSub.alt;
 } salt03;
 
-feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+lookup salt04 {
+	sub ampersand by ampersand.001;
+} salt04;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+feature locl { # Localized Forms
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
+
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature pnum {
@@ -251,17 +282,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -340,6 +360,17 @@ feature frac { # Fractions
 	language CRT;
 
 	script cyrl;
+	language MKD;
+	lookup frac12;
+	lookup frac13;
+	lookup frac14;
+	lookup frac15;
+	language SRB;
+	lookup frac12;
+	lookup frac13;
+	lookup frac14;
+	lookup frac15;
+	language dflt;
 	lookup frac12;
 	lookup frac13;
 	lookup frac14;
@@ -364,6 +395,9 @@ feature case { # Case-Sensitive Forms
   script cyrl;
   lookup case_add;
   lookup case_dflt;
+	language BGR;
+	language MKD;
+	language SRB;
 
   script grek;
   lookup case_add;
@@ -371,17 +405,47 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature liga { # Standard Ligatures
-	script latn;
-	lookup ligatures;
-	language AZE;
-	language TRK;
-	language CRT;
-
 	script cyrl;
-	lookup ligatures;
+	language MKD ;
+	lookup liga_cyrl_MKD_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_cyrl_MKD_1;
+
+	language SRB ;
+	lookup liga_cyrl_MKD_1;
+	language dflt;
+	lookup liga_cyrl_MKD_1;
 
 	script grek;
-	lookup ligatures;
+	language dflt;
+	lookup liga_grek_dflt_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_grek_dflt_1;
+
+	script latn;
+	language AZE;
+	lookup liga_latn_AZE_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_latn_AZE_1;
+
+	language CRT ;
+	lookup liga_latn_AZE_1;
+	language TRK ;
+	lookup liga_latn_AZE_1;
+	language dflt;
+	lookup liga_latn_AZE_1;
 } liga;
 
 feature ss01 { # Greek Stylistic Alternates
@@ -389,10 +453,20 @@ feature ss01 { # Greek Stylistic Alternates
 	lookup salt01;
 	lookup salt02;
 	lookup salt03;
+
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
 } ss01;
 
 feature salt { # Stylistic Alternates
 	script grek; # Greek
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
+	script latn;
 	lookup salt01;
 	lookup salt02;
 	lookup salt03;

--- a/source/Ubuntu-R.ufo/features.fea
+++ b/source/Ubuntu-R.ufo/features.fea
@@ -27,12 +27,15 @@
 @OmegaSub = [uni1FA8 uni1FA9 uni1FAA uni1FAB uni1FAC uni1FAD uni1FAE uni1FAF uni1FFC];
 @OmegaSub.alt = [uni1FA8.alt uni1FA9.alt uni1FAA.alt uni1FAB.alt uni1FAC.alt uni1FAD.alt uni1FAE.alt uni1FAF.alt uni1FFC.alt];
 
-# languagesystem DFLT dflt;
+languagesystem DFLT dflt;
 languagesystem latn dflt;
 languagesystem latn AZE;
 languagesystem latn CRT;
+languagesystem latn MOL;
+languagesystem latn ROM;
 languagesystem latn TRK;
 languagesystem cyrl dflt;
+languagesystem cyrl BGR;
 languagesystem cyrl MKD;
 languagesystem cyrl SRB;
 languagesystem grek dflt;
@@ -182,19 +185,37 @@ lookup salt03 {
 } salt03;
 
 feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature pnum {
@@ -204,6 +225,8 @@ feature pnum {
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup pnum_text;
@@ -211,6 +234,7 @@ feature pnum {
 	lookup pnum_text;
  	language SRB; # Serbian
  	language MKD; # Macedonian
+	language BGR;
 } pnum;
 
 feature tnum {
@@ -219,11 +243,14 @@ feature tnum {
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup tnum_text;
 	script cyrl; # Cyrillic
 	lookup tnum_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } tnum;
@@ -234,12 +261,15 @@ feature numr { # Numerators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup numr_text;
 
 	script cyrl; # Cyrillic
 	lookup numr_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } numr;
@@ -247,17 +277,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -266,12 +285,15 @@ feature dnom { # Denominators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup dnom_text;
 
 	script cyrl; # Cyrillic
 	lookup dnom_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } dnom;
@@ -282,12 +304,15 @@ feature sups { # Superscript
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sups_text;
 
 	script cyrl; # Cyrillic
 	lookup sups_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } sups;
@@ -298,12 +323,15 @@ feature subs { # Subscripts
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sub1;
 
 	script cyrl; # Cyrillic
 	lookup sub1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } subs;
@@ -314,15 +342,17 @@ feature sinf { # Scientific Inferiors
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sin1;
 
 	script cyrl; # Cyrillic
 	lookup sin1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
-
 } sinf;
 
 feature frac { # Fractions
@@ -334,12 +364,17 @@ feature frac { # Fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
 	lookup frac12;
 	lookup frac13;
 	lookup frac14;
 	lookup frac15;
+	language BGR;
+	language MKD;
+	language SRB;
 
 	script grek;
 	lookup frac12;
@@ -353,13 +388,16 @@ feature case { # Case-Sensitive Forms
   script latn;
   lookup case_add;
   lookup case_dflt;
-  language AZE;
-  language TRK;
-  language CRT;
+	language AZE;
+	language TRK;
+	language CRT;
 
   script cyrl;
   lookup case_add;
   lookup case_dflt;
+	language BGR;
+	language MKD;
+	language SRB;
 
   script grek;
   lookup case_add;
@@ -367,20 +405,54 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature liga { # Standard Ligatures
-	script latn;
-	lookup ligatures;
-	language AZE;
-	language TRK;
-	language CRT;
-
 	script cyrl;
-	lookup ligatures;
+  language dflt;
+  lookup liga_cyrl_dflt_1 {
+    sub f f by f_f;
+    sub f f i by f_f_i;
+    sub f f l by f_f_l;
+    sub f i by f_i;
+    sub f l by f_l;
+  } liga_cyrl_dflt_1;
 
-	script grek;
-	lookup ligatures;
+  script grek;
+  language dflt;
+  lookup liga_grek_dflt_1 {
+    sub f f by f_f;
+    sub f f i by f_f_i;
+    sub f f l by f_f_l;
+    sub f i by f_i;
+    sub f l by f_l;
+  } liga_grek_dflt_1;
+
+  script latn;
+  language AZE;
+  lookup liga_latn_AZE_1 {
+    sub f f by f_f;
+    sub f f i by f_f_i;
+    sub f f l by f_f_l;
+    sub f i by f_i;
+    sub f l by f_l;
+  } liga_latn_AZE_1;
+
+  language CRT ;
+  lookup liga_latn_AZE_1;
+  language MOL ;
+  lookup liga_latn_AZE_1;
+  language ROM ;
+  lookup liga_latn_AZE_1;
+  language TRK ;
+  lookup liga_latn_AZE_1;
+  language dflt;
+  lookup liga_latn_AZE_1;
 } liga;
 
 feature ss01 { # Greek Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;
@@ -388,6 +460,11 @@ feature ss01 { # Greek Stylistic Alternates
 } ss01;
 
 feature salt { # Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;

--- a/source/Ubuntu-RI.ufo/features.fea
+++ b/source/Ubuntu-RI.ufo/features.fea
@@ -27,12 +27,13 @@
 @OmegaSub = [uni1FA8 uni1FA9 uni1FAA uni1FAB uni1FAC uni1FAD uni1FAE uni1FAF uni1FFC];
 @OmegaSub.alt = [uni1FA8.alt uni1FA9.alt uni1FAA.alt uni1FAB.alt uni1FAC.alt uni1FAD.alt uni1FAE.alt uni1FAF.alt uni1FFC.alt];
 
-# languagesystem DFLT dflt;
+languagesystem DFLT dflt;
 languagesystem latn dflt;
 languagesystem latn AZE;
 languagesystem latn CRT;
 languagesystem latn TRK;
 languagesystem cyrl dflt;
+languagesystem cyrl BGR;
 languagesystem cyrl MKD;
 languagesystem cyrl SRB;
 languagesystem grek dflt;
@@ -185,20 +186,50 @@ lookup salt03 {
 	sub @OmegaSub by @OmegaSub.alt;
 } salt03;
 
-feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+lookup salt04 {
+	sub ampersand by ampersand.001;
+} salt04;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+feature locl { # Localized Forms
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
+
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature pnum {
@@ -251,17 +282,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -340,6 +360,17 @@ feature frac { # Fractions
 	language CRT;
 
 	script cyrl;
+	language MKD;
+	lookup frac12;
+	lookup frac13;
+	lookup frac14;
+	lookup frac15;
+	language SRB;
+	lookup frac12;
+	lookup frac13;
+	lookup frac14;
+	lookup frac15;
+	language dflt;
 	lookup frac12;
 	lookup frac13;
 	lookup frac14;
@@ -364,6 +395,9 @@ feature case { # Case-Sensitive Forms
   script cyrl;
   lookup case_add;
   lookup case_dflt;
+	language BGR;
+	language MKD;
+	language SRB;
 
   script grek;
   lookup case_add;
@@ -371,17 +405,47 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature liga { # Standard Ligatures
-	script latn;
-	lookup ligatures;
-	language AZE;
-	language TRK;
-	language CRT;
-
 	script cyrl;
-	lookup ligatures;
+	language MKD ;
+	lookup liga_cyrl_MKD_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_cyrl_MKD_1;
+
+	language SRB ;
+	lookup liga_cyrl_MKD_1;
+	language dflt;
+	lookup liga_cyrl_MKD_1;
 
 	script grek;
-	lookup ligatures;
+	language dflt;
+	lookup liga_grek_dflt_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_grek_dflt_1;
+
+	script latn;
+	language AZE;
+	lookup liga_latn_AZE_1 {
+		sub f f by f_f;
+		sub f f i by f_f_i;
+		sub f f l by f_f_l;
+		sub f i by f_i;
+		sub f l by f_l;
+	} liga_latn_AZE_1;
+
+	language CRT ;
+	lookup liga_latn_AZE_1;
+	language TRK ;
+	lookup liga_latn_AZE_1;
+	language dflt;
+	lookup liga_latn_AZE_1;
 } liga;
 
 feature ss01 { # Greek Stylistic Alternates
@@ -389,10 +453,20 @@ feature ss01 { # Greek Stylistic Alternates
 	lookup salt01;
 	lookup salt02;
 	lookup salt03;
+
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
 } ss01;
 
 feature salt { # Stylistic Alternates
 	script grek; # Greek
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
+	script latn;
 	lookup salt01;
 	lookup salt02;
 	lookup salt03;

--- a/source/UbuntuMono-B.ufo/features.fea
+++ b/source/UbuntuMono-B.ufo/features.fea
@@ -162,19 +162,37 @@ lookup salt03 {
 } salt03;
 
 feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature numr { # Numerators
@@ -183,12 +201,15 @@ feature numr { # Numerators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup numr_text;
 
 	script cyrl; # Cyrillic
 	lookup numr_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } numr;
@@ -196,17 +217,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -215,14 +225,21 @@ feature dnom { # Denominators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup dnom_text;
 
 	script cyrl; # Cyrillic
+	language BGR;
 	lookup dnom_text;
 	language SRB; # Serbian
+	lookup dnom_text;
 	language MKD; # Macedonian
+	lookup dnom_text;
+	language dflt; # Macedonian
+	lookup dnom_text;
 } dnom;
 
 feature sups { # Superscript
@@ -231,12 +248,15 @@ feature sups { # Superscript
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sups_text;
 
 	script cyrl; # Cyrillic
 	lookup sups_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } sups;
@@ -247,12 +267,15 @@ feature subs { # Subscripts
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sub1;
 
 	script cyrl; # Cyrillic
 	lookup sub1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } subs;
@@ -263,12 +286,15 @@ feature sinf { # Scientific Inferiors
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sin1;
 
 	script cyrl; # Cyrillic
 	lookup sin1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 
@@ -281,8 +307,20 @@ feature frac { # Fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
+	language BGR;
+	lookup frac12;
+	lookup frac13;
+	language MKD;
+	lookup frac12;
+	lookup frac13;
+	language SRB;
+	lookup frac12;
+	lookup frac13;
+	language dflt;
 	lookup frac12;
 	lookup frac13;
 
@@ -302,8 +340,23 @@ feature afrc { # Alternate fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
+	language BGR;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language MKD;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language SRB;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language dflt;
 	lookup afrc1;
 	lookup afrc2;
 	lookup afrc3;
@@ -323,11 +376,16 @@ feature ss02 {
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
 	lookup afrc1;
 	lookup afrc2;
 	lookup afrc3;
+	language BGR;
+	language MKD;
+	language SRB;
 
 	script grek;
 	lookup afrc1;
@@ -345,8 +403,18 @@ feature case { # Case-Sensitive Forms
   language CRT;
 
   script cyrl;
+	language BGR;
   lookup case_add;
   lookup case_dflt;
+	language MKD;
+	lookup case_add;
+	lookup case_dflt;
+	language SRB;
+	lookup case_add;
+	lookup case_dflt;
+	language dflt;
+	lookup case_add;
+	lookup case_dflt;
 
   script grek;
   lookup case_add;
@@ -354,6 +422,11 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature ss01 { # Greek Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;
@@ -361,6 +434,11 @@ feature ss01 { # Greek Stylistic Alternates
 } ss01;
 
 feature salt { # Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;

--- a/source/UbuntuMono-BI.ufo/features.fea
+++ b/source/UbuntuMono-BI.ufo/features.fea
@@ -42,10 +42,10 @@ lookup locl_TRK {
 
 lookup locl_SRB {
 	sub afii10066 by afii10066.locl;
-  sub afii10068 by afii10068.locl.ita;
-  sub afii10069 by afii10069.locl.ita;
-  sub afii10081 by afii10081.locl.ita;
-  sub afii10084 by afii10084.locl.ita;
+	sub afii10068 by afii10068.locl.ita;
+	sub afii10069 by afii10069.locl.ita;
+	sub afii10081 by afii10081.locl.ita;
+	sub afii10084 by afii10084.locl.ita;
 } locl_SRB;
 
 lookup numr_text {
@@ -166,19 +166,45 @@ lookup salt03 {
 } salt03;
 
 feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature numr { # Numerators
@@ -187,12 +213,15 @@ feature numr { # Numerators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup numr_text;
 
 	script cyrl; # Cyrillic
 	lookup numr_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } numr;
@@ -200,17 +229,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -219,14 +237,21 @@ feature dnom { # Denominators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup dnom_text;
 
 	script cyrl; # Cyrillic
+	language BGR;
 	lookup dnom_text;
 	language SRB; # Serbian
+	lookup dnom_text;
 	language MKD; # Macedonian
+	lookup dnom_text;
+	language dflt; # Macedonian
+	lookup dnom_text;
 } dnom;
 
 feature sups { # Superscript
@@ -235,12 +260,15 @@ feature sups { # Superscript
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sups_text;
 
 	script cyrl; # Cyrillic
 	lookup sups_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } sups;
@@ -251,12 +279,15 @@ feature subs { # Subscripts
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sub1;
 
 	script cyrl; # Cyrillic
 	lookup sub1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } subs;
@@ -267,12 +298,15 @@ feature sinf { # Scientific Inferiors
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sin1;
 
 	script cyrl; # Cyrillic
 	lookup sin1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 
@@ -285,8 +319,20 @@ feature frac { # Fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
+	language BGR;
+	lookup frac12;
+	lookup frac13;
+	language MKD;
+	lookup frac12;
+	lookup frac13;
+	language SRB;
+	lookup frac12;
+	lookup frac13;
+	language dflt;
 	lookup frac12;
 	lookup frac13;
 
@@ -306,8 +352,23 @@ feature afrc { # Alternate fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
+	language BGR;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language MKD;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language SRB;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language dflt;
 	lookup afrc1;
 	lookup afrc2;
 	lookup afrc3;
@@ -327,11 +388,16 @@ feature ss02 {
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
 	lookup afrc1;
 	lookup afrc2;
 	lookup afrc3;
+	language BGR;
+	language MKD;
+	language SRB;
 
 	script grek;
 	lookup afrc1;
@@ -349,8 +415,18 @@ feature case { # Case-Sensitive Forms
   language CRT;
 
   script cyrl;
+	language BGR;
   lookup case_add;
   lookup case_dflt;
+	language MKD;
+	lookup case_add;
+	lookup case_dflt;
+	language SRB;
+	lookup case_add;
+	lookup case_dflt;
+	language dflt;
+	lookup case_add;
+	lookup case_dflt;
 
   script grek;
   lookup case_add;
@@ -358,6 +434,11 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature ss01 { # Greek Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;
@@ -365,6 +446,11 @@ feature ss01 { # Greek Stylistic Alternates
 } ss01;
 
 feature salt { # Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;

--- a/source/UbuntuMono-R.ufo/features.fea
+++ b/source/UbuntuMono-R.ufo/features.fea
@@ -162,19 +162,37 @@ lookup salt03 {
 } salt03;
 
 feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature numr { # Numerators
@@ -183,12 +201,15 @@ feature numr { # Numerators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup numr_text;
 
 	script cyrl; # Cyrillic
 	lookup numr_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } numr;
@@ -196,17 +217,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -215,14 +225,21 @@ feature dnom { # Denominators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup dnom_text;
 
 	script cyrl; # Cyrillic
+	language BGR;
 	lookup dnom_text;
 	language SRB; # Serbian
+	lookup dnom_text;
 	language MKD; # Macedonian
+	lookup dnom_text;
+	language dflt; # Macedonian
+	lookup dnom_text;
 } dnom;
 
 feature sups { # Superscript
@@ -231,12 +248,15 @@ feature sups { # Superscript
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sups_text;
 
 	script cyrl; # Cyrillic
 	lookup sups_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } sups;
@@ -247,12 +267,15 @@ feature subs { # Subscripts
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sub1;
 
 	script cyrl; # Cyrillic
 	lookup sub1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } subs;
@@ -263,12 +286,15 @@ feature sinf { # Scientific Inferiors
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sin1;
 
 	script cyrl; # Cyrillic
 	lookup sin1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 
@@ -281,8 +307,20 @@ feature frac { # Fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
+	language BGR;
+	lookup frac12;
+	lookup frac13;
+	language MKD;
+	lookup frac12;
+	lookup frac13;
+	language SRB;
+	lookup frac12;
+	lookup frac13;
+	language dflt;
 	lookup frac12;
 	lookup frac13;
 
@@ -302,8 +340,23 @@ feature afrc { # Alternate fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
+	language BGR;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language MKD;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language SRB;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language dflt;
 	lookup afrc1;
 	lookup afrc2;
 	lookup afrc3;
@@ -323,11 +376,16 @@ feature ss02 {
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
 	lookup afrc1;
 	lookup afrc2;
 	lookup afrc3;
+	language BGR;
+	language MKD;
+	language SRB;
 
 	script grek;
 	lookup afrc1;
@@ -345,8 +403,18 @@ feature case { # Case-Sensitive Forms
   language CRT;
 
   script cyrl;
+	language BGR;
   lookup case_add;
   lookup case_dflt;
+	language MKD;
+	lookup case_add;
+	lookup case_dflt;
+	language SRB;
+	lookup case_add;
+	lookup case_dflt;
+	language dflt;
+	lookup case_add;
+	lookup case_dflt;
 
   script grek;
   lookup case_add;
@@ -354,6 +422,11 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature ss01 { # Greek Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;
@@ -361,6 +434,11 @@ feature ss01 { # Greek Stylistic Alternates
 } ss01;
 
 feature salt { # Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;

--- a/source/UbuntuMono-RI.ufo/features.fea
+++ b/source/UbuntuMono-RI.ufo/features.fea
@@ -42,10 +42,10 @@ lookup locl_TRK {
 
 lookup locl_SRB {
 	sub afii10066 by afii10066.locl;
-  sub afii10068 by afii10068.locl.ita;
-  sub afii10069 by afii10069.locl.ita;
-  sub afii10081 by afii10081.locl.ita;
-  sub afii10084 by afii10084.locl.ita;
+	sub afii10068 by afii10068.locl.ita;
+	sub afii10069 by afii10069.locl.ita;
+	sub afii10081 by afii10081.locl.ita;
+	sub afii10084 by afii10084.locl.ita;
 } locl_SRB;
 
 lookup numr_text {
@@ -166,19 +166,45 @@ lookup salt03 {
 } salt03;
 
 feature locl { # Localized Forms
-	script latn; # Latin
-	language AZE  exclude_dflt; # Azeri
-	lookup locl_TRK;
-	language TRK  exclude_dflt; # Turkish
-	lookup locl_TRK;
-	language CRT  exclude_dflt; # Crimean Tatar
-	lookup locl_TRK;
+	script cyrl;
+	language BGR;
+	lookup locl_cyrl_BGR_1 {
+		sub afii10066 by afii10066.locl;
+	} locl_cyrl_BGR_1;
 
-	script cyrl; # Cyrillic
-	language MKD  exclude_dflt; # Macedonian
-	lookup locl_SRB;
-	language SRB  exclude_dflt; # Serbian
-	lookup locl_SRB;
+	language MKD;
+	lookup locl_cyrl_MKD_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_MKD_1;
+
+	language SRB;
+	lookup locl_cyrl_SRB_1 {
+		sub afii10066 by afii10066.locl;
+		sub afii10068 by afii10068.locl.ita;
+		sub afii10069 by afii10069.locl.ita;
+		sub afii10081 by afii10081.locl.ita;
+		sub afii10084 by afii10084.locl.ita;
+	} locl_cyrl_SRB_1;
+
+	script latn;
+	language AZE;
+	lookup locl_latn_AZE_1 {
+		sub i by i.locl;
+	} locl_latn_AZE_1;
+
+	language CRT;
+	lookup locl_latn_CRT_1 {
+		sub i by i.locl;
+	} locl_latn_CRT_1;
+
+	language TRK;
+	lookup locl_latn_TRK_1 {
+		sub i by i.locl;
+	} locl_latn_TRK_1;
 } locl;
 
 feature numr { # Numerators
@@ -187,12 +213,15 @@ feature numr { # Numerators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup numr_text;
 
 	script cyrl; # Cyrillic
 	lookup numr_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } numr;
@@ -200,17 +229,6 @@ feature numr { # Numerators
 feature ordn {
 	script latn; # Latin
 	lookup ordn_ao;
-	language AZE; # Azeri
-	language TRK; # Turkish
-	language CRT; # Crimean Tatar
-
-	script grek; # Greek
-	lookup ordn_ao;
-
-	script cyrl; # Cyrillic
-	lookup ordn_ao;
-	language SRB; # Serbian
-	language MKD; # Macedonian
 } ordn;
 
 feature dnom { # Denominators
@@ -219,14 +237,21 @@ feature dnom { # Denominators
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL;
+	language ROM;
 
 	script grek; # Greek
 	lookup dnom_text;
 
 	script cyrl; # Cyrillic
+	language BGR;
 	lookup dnom_text;
 	language SRB; # Serbian
+	lookup dnom_text;
 	language MKD; # Macedonian
+	lookup dnom_text;
+	language dflt; # Macedonian
+	lookup dnom_text;
 } dnom;
 
 feature sups { # Superscript
@@ -235,12 +260,15 @@ feature sups { # Superscript
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sups_text;
 
 	script cyrl; # Cyrillic
 	lookup sups_text;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } sups;
@@ -251,12 +279,15 @@ feature subs { # Subscripts
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sub1;
 
 	script cyrl; # Cyrillic
 	lookup sub1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 } subs;
@@ -267,12 +298,15 @@ feature sinf { # Scientific Inferiors
 	language AZE; # Azeri
 	language TRK; # Turkish
 	language CRT; # Crimean Tatar
+	language MOL ;
+	language ROM ;
 
 	script grek; # Greek
 	lookup sin1;
 
 	script cyrl; # Cyrillic
 	lookup sin1;
+	language BGR;
 	language SRB; # Serbian
 	language MKD; # Macedonian
 
@@ -285,8 +319,20 @@ feature frac { # Fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
+	language BGR;
+	lookup frac12;
+	lookup frac13;
+	language MKD;
+	lookup frac12;
+	lookup frac13;
+	language SRB;
+	lookup frac12;
+	lookup frac13;
+	language dflt;
 	lookup frac12;
 	lookup frac13;
 
@@ -306,8 +352,23 @@ feature afrc { # Alternate fractions
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
+	language BGR;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language MKD;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language SRB;
+	lookup afrc1;
+	lookup afrc2;
+	lookup afrc3;
+	language dflt;
 	lookup afrc1;
 	lookup afrc2;
 	lookup afrc3;
@@ -327,11 +388,16 @@ feature ss02 {
 	language AZE;
 	language TRK;
 	language CRT;
+	language MOL;
+	language ROM;
 
 	script cyrl;
 	lookup afrc1;
 	lookup afrc2;
 	lookup afrc3;
+	language BGR;
+	language MKD;
+	language SRB;
 
 	script grek;
 	lookup afrc1;
@@ -349,8 +415,18 @@ feature case { # Case-Sensitive Forms
   language CRT;
 
   script cyrl;
+	language BGR;
   lookup case_add;
   lookup case_dflt;
+	language MKD;
+	lookup case_add;
+	lookup case_dflt;
+	language SRB;
+	lookup case_add;
+	lookup case_dflt;
+	language dflt;
+	lookup case_add;
+	lookup case_dflt;
 
   script grek;
   lookup case_add;
@@ -358,6 +434,11 @@ feature case { # Case-Sensitive Forms
 } case;
 
 feature ss01 { # Greek Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;
@@ -365,6 +446,11 @@ feature ss01 { # Greek Stylistic Alternates
 } ss01;
 
 feature salt { # Stylistic Alternates
+	script latn;
+	lookup salt01;
+	lookup salt02;
+	lookup salt03;
+
 	script grek; # Greek
 	lookup salt01;
 	lookup salt02;


### PR DESCRIPTION
All feature files were modified to decompile to almost the same file as
the GSUB dump from the corresponding GF release.

Only difference: fonttools adds a "languagesystem DFLT dflt;" at the
top in LI, RI, MI and BI.

Equivalence was tested with Adobe AFDKO's ttxn tool which outputs
feature files instead of raw XML table dumps. In the following shell
snippet, `/tmp/font1` houses the Google Fonts release with the filenames
changed to match the UFO source file names, `/tmp/font2` houses the
compiled UFO builds.

```
for f in /tmp1/font1/*ttf; do ttxn -t GSUB $f; done
for r in -L -LI -M -MI -R -RI -B -BI Mono-R Mono-RI Mono-B Mono-BI; do
  export REL=$r
  python ./tools/build.py ./source/Ubuntu$REL.ufo /tmp/font2/Ubuntu$REL.ttf
  ttxn -t GSUB -o /tmp/font2/Ubuntu$REL.ttx /tmp/font2/Ubuntu$REL.ttf
  diff -U2 /tmp/font1/Ubuntu$REL.ttf /tmp/font2/Ubuntu$REL.ttf
done
```

The above mentioned difference should be the only one.