### PR TITLE
Modify name table to pass more fontbakery checks

### DIFF
--- a/source/Ubuntu-B.ufo/fontinfo.plist
+++ b/source/Ubuntu-B.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -75,16 +75,16 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com/</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNameRecords</key>

--- a/source/Ubuntu-BI.ufo/fontinfo.plist
+++ b/source/Ubuntu-BI.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -69,16 +69,16 @@
 		<integer>28</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Bold Italic</string>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com/</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNamePreferredFamilyName</key>

--- a/source/Ubuntu-C.ufo/fontinfo.plist
+++ b/source/Ubuntu-C.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -111,16 +111,16 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNameRecords</key>

--- a/source/Ubuntu-L.ufo/fontinfo.plist
+++ b/source/Ubuntu-L.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -73,16 +73,16 @@
 		<integer>28</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Light</string>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNamePreferredFamilyName</key>

--- a/source/Ubuntu-LI.ufo/fontinfo.plist
+++ b/source/Ubuntu-LI.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -113,16 +113,16 @@
 		<integer>28</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Light Italic</string>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNamePreferredFamilyName</key>

--- a/source/Ubuntu-M.ufo/fontinfo.plist
+++ b/source/Ubuntu-M.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -81,16 +81,16 @@
 		<integer>28</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Medium</string>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNamePreferredFamilyName</key>

--- a/source/Ubuntu-MI.ufo/fontinfo.plist
+++ b/source/Ubuntu-MI.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -73,16 +73,16 @@
 		<integer>28</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Medium Italic</string>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNamePreferredFamilyName</key>

--- a/source/Ubuntu-R.ufo/fontinfo.plist
+++ b/source/Ubuntu-R.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -49,6 +49,8 @@
 		<integer>128</integer>
 		<key>macintoshFONDName</key>
 		<string>Ubuntu</string>
+		<key>note</key>
+		<string></string>
 		<key>openTypeGaspRangeRecords</key>
 		<array>
 			<dict>
@@ -77,6 +79,8 @@
 				<integer>65535</integer>
 			</dict>
 		</array>
+		<key>openTypeHeadCreated</key>
+		<string>2017/12/26 21:30:36</string>
 		<key>openTypeHeadFlags</key>
 		<array>
 			<integer>0</integer>
@@ -91,16 +95,16 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com/</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNameRecords</key>

--- a/source/Ubuntu-RI.ufo/fontinfo.plist
+++ b/source/Ubuntu-RI.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -79,16 +79,16 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com/</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNameRecords</key>

--- a/source/UbuntuMono-B.ufo/fontinfo.plist
+++ b/source/UbuntuMono-B.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -53,16 +53,16 @@
 		<integer>-170</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>0</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com/</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNameRecords</key>

--- a/source/UbuntuMono-BI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-BI.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -61,16 +61,16 @@
 		<integer>-170</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>0</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com/</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNameRecords</key>

--- a/source/UbuntuMono-R.ufo/fontinfo.plist
+++ b/source/UbuntuMono-R.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -53,16 +53,16 @@
 		<integer>-170</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>0</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com/</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNameRecords</key>

--- a/source/UbuntuMono-RI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-RI.ufo/fontinfo.plist
@@ -7,7 +7,7 @@
 		<key>capHeight</key>
 		<integer>693</integer>
 		<key>copyright</key>
-		<string>Copyright 2011 Canonical Ltd.  Licensed under the Ubuntu Font Licence 1.0</string>
+		<string>Copyright 2011 Canonical Ltd.</string>
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
@@ -53,16 +53,16 @@
 		<integer>-170</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>0</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameDesignerURL</key>
 		<string>http://www.daltonmaag.com/</string>
+		<key>openTypeNameLicense</key>
+		<string>Licensed under the Ubuntu Font Licence 1.0.</string>
+		<key>openTypeNameLicenseURL</key>
+		<string>https://www.ubuntu.com/legal/terms-and-policies/font-licence</string>
 		<key>openTypeNameManufacturer</key>
-		<string>Dalton Maag Ltd</string>
+		<string>Dalton Maag Limited</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
 		<key>openTypeNameRecords</key>


### PR DESCRIPTION
1. Delete openTypeNameDescription as it was deemed too long.
2. Change openTypeNameDesigner and openTypeNameManufacturer to "Dalton
Maag Limited", as that is what the vendor id DAMA resolves to
officially.
3. Insert openTypeNameLicense and openTypeNameLicenseURL.

More modifications are necessary: should openTypeNameLicense spell out the entire license text?