### PR TITLE
Rename "Ubuntu Monospaced" to "Ubuntu Mono"

### DIFF
--- a/source/UbuntuMono-B.ufo/fontinfo.plist
+++ b/source/UbuntuMono-B.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Monospaced</string>
+		<string>Ubuntu Mono</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -28,7 +28,7 @@
 		<key>macintoshFONDFamilyID</key>
 		<integer>128</integer>
 		<key>macintoshFONDName</key>
-		<string>Ubuntu Monospaced Bold</string>
+		<string>Ubuntu Mono Bold</string>
 		<key>openTypeGaspRangeRecords</key>
 		<array>
 			<dict>
@@ -194,7 +194,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>postscriptForceBold</key>
 		<false/>
 		<key>postscriptFullName</key>
-		<string>Ubuntu Monospaced Bold</string>
+		<string>Ubuntu Mono Bold</string>
 		<key>postscriptIsFixedPitch</key>
 		<true/>
 		<key>postscriptOtherBlues</key>
@@ -219,7 +219,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>postscriptWindowsCharacterSet</key>
 		<integer>1</integer>
 		<key>styleMapFamilyName</key>
-		<string>Ubuntu Monospaced</string>
+		<string>Ubuntu Mono</string>
 		<key>styleMapStyleName</key>
 		<string>bold</string>
 		<key>styleName</key>

--- a/source/UbuntuMono-BI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-BI.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Monospaced</string>
+		<string>Ubuntu Mono</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -36,7 +36,7 @@
 		<key>macintoshFONDFamilyID</key>
 		<integer>128</integer>
 		<key>macintoshFONDName</key>
-		<string>Ubuntu Monospaced Bold Italic</string>
+		<string>Ubuntu Mono Bold Italic</string>
 		<key>openTypeGaspRangeRecords</key>
 		<array>
 			<dict>
@@ -202,7 +202,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>postscriptForceBold</key>
 		<false/>
 		<key>postscriptFullName</key>
-		<string>Ubuntu Monospaced Bold Italic</string>
+		<string>Ubuntu Mono Bold Italic</string>
 		<key>postscriptIsFixedPitch</key>
 		<true/>
 		<key>postscriptOtherBlues</key>
@@ -227,7 +227,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>postscriptWindowsCharacterSet</key>
 		<integer>1</integer>
 		<key>styleMapFamilyName</key>
-		<string>Ubuntu Monospaced</string>
+		<string>Ubuntu Mono</string>
 		<key>styleMapStyleName</key>
 		<string>bold italic</string>
 		<key>styleName</key>

--- a/source/UbuntuMono-R.ufo/fontinfo.plist
+++ b/source/UbuntuMono-R.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Monospaced</string>
+		<string>Ubuntu Mono</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -28,7 +28,7 @@
 		<key>macintoshFONDFamilyID</key>
 		<integer>128</integer>
 		<key>macintoshFONDName</key>
-		<string>Ubuntu Monospaced</string>
+		<string>Ubuntu Mono</string>
 		<key>openTypeGaspRangeRecords</key>
 		<array>
 			<dict>
@@ -194,7 +194,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>postscriptForceBold</key>
 		<false/>
 		<key>postscriptFullName</key>
-		<string>Ubuntu Monospaced</string>
+		<string>Ubuntu Mono</string>
 		<key>postscriptIsFixedPitch</key>
 		<true/>
 		<key>postscriptOtherBlues</key>
@@ -219,7 +219,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>postscriptWindowsCharacterSet</key>
 		<integer>1</integer>
 		<key>styleMapFamilyName</key>
-		<string>Ubuntu Monospaced</string>
+		<string>Ubuntu Mono</string>
 		<key>styleMapStyleName</key>
 		<string>regular</string>
 		<key>styleName</key>

--- a/source/UbuntuMono-RI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-RI.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Monospaced</string>
+		<string>Ubuntu Mono</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -28,7 +28,7 @@
 		<key>macintoshFONDFamilyID</key>
 		<integer>128</integer>
 		<key>macintoshFONDName</key>
-		<string>Ubuntu Monospaced Italic</string>
+		<string>Ubuntu Mono Italic</string>
 		<key>openTypeGaspRangeRecords</key>
 		<array>
 			<dict>
@@ -194,7 +194,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>postscriptForceBold</key>
 		<false/>
 		<key>postscriptFullName</key>
-		<string>Ubuntu Monospaced Italic</string>
+		<string>Ubuntu Mono Italic</string>
 		<key>postscriptIsFixedPitch</key>
 		<true/>
 		<key>postscriptOtherBlues</key>
@@ -219,7 +219,7 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>postscriptWindowsCharacterSet</key>
 		<integer>1</integer>
 		<key>styleMapFamilyName</key>
-		<string>Ubuntu Monospaced</string>
+		<string>Ubuntu Mono</string>
 		<key>styleMapStyleName</key>
 		<string>italic</string>
 		<key>styleName</key>


### PR DESCRIPTION
Named that way in the GF release.