### PR TITLE
Remove openTypeNameDescription

### DIFF
--- a/source/Ubuntu-B.ufo/fontinfo.plist
+++ b/source/Ubuntu-B.ufo/fontinfo.plist
@@ -77,10 +77,6 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/Ubuntu-BI.ufo/fontinfo.plist
+++ b/source/Ubuntu-BI.ufo/fontinfo.plist
@@ -71,10 +71,6 @@
 		<integer>28</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Bold Italic</string>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/Ubuntu-C.ufo/fontinfo.plist
+++ b/source/Ubuntu-C.ufo/fontinfo.plist
@@ -113,10 +113,6 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/Ubuntu-L.ufo/fontinfo.plist
+++ b/source/Ubuntu-L.ufo/fontinfo.plist
@@ -75,10 +75,6 @@
 		<integer>28</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Light</string>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/Ubuntu-LI.ufo/fontinfo.plist
+++ b/source/Ubuntu-LI.ufo/fontinfo.plist
@@ -115,10 +115,6 @@
 		<integer>28</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Light Italic</string>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/Ubuntu-M.ufo/fontinfo.plist
+++ b/source/Ubuntu-M.ufo/fontinfo.plist
@@ -83,10 +83,6 @@
 		<integer>28</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Medium</string>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/Ubuntu-MI.ufo/fontinfo.plist
+++ b/source/Ubuntu-MI.ufo/fontinfo.plist
@@ -75,10 +75,6 @@
 		<integer>28</integer>
 		<key>openTypeNameCompatibleFullName</key>
 		<string>Ubuntu Medium Italic</string>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/Ubuntu-R.ufo/fontinfo.plist
+++ b/source/Ubuntu-R.ufo/fontinfo.plist
@@ -93,10 +93,6 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/Ubuntu-RI.ufo/fontinfo.plist
+++ b/source/Ubuntu-RI.ufo/fontinfo.plist
@@ -81,10 +81,6 @@
 		<integer>-189</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>28</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/UbuntuMono-B.ufo/fontinfo.plist
+++ b/source/UbuntuMono-B.ufo/fontinfo.plist
@@ -55,10 +55,6 @@
 		<integer>-170</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>0</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/UbuntuMono-BI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-BI.ufo/fontinfo.plist
@@ -63,10 +63,6 @@
 		<integer>-170</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>0</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/UbuntuMono-R.ufo/fontinfo.plist
+++ b/source/UbuntuMono-R.ufo/fontinfo.plist
@@ -55,10 +55,6 @@
 		<integer>-170</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>0</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>

--- a/source/UbuntuMono-RI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-RI.ufo/fontinfo.plist
@@ -55,10 +55,6 @@
 		<integer>-170</integer>
 		<key>openTypeHheaLineGap</key>
 		<integer>0</integer>
-		<key>openTypeNameDescription</key>
-		<string>The Ubuntu Font Family are libre fonts funded by Canonical Ltd on behalf of the Ubuntu project. The font design work and technical implementation is being undertaken by Dalton Maag. The typeface is sans-serif, uses OpenType features and is manually hinted for clarity on desktop and mobile computing screens.
-
-The scope of the Ubuntu Font Family includes all the languages used by the various Ubuntu users around the world in tune with Ubuntu's philosophy which states that every user should be able to use their software in the language of their choice. The project is ongoing, and we expect the family will be extended to cover many written languages in the coming years.</string>
 		<key>openTypeNameDesigner</key>
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameDesignerURL</key>


### PR DESCRIPTION
Fontbakery flagged it as too long and it's not present in the GF
release.