### PR TITLE
Remove openTypeNameUniqueID from UFOs

### DIFF
--- a/source/Ubuntu-B.ufo/fontinfo.plist
+++ b/source/Ubuntu-B.ufo/fontinfo.plist
@@ -92,8 +92,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Bold Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-BI.ufo/fontinfo.plist
+++ b/source/Ubuntu-BI.ufo/fontinfo.plist
@@ -90,8 +90,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu BoldItalic Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-C.ufo/fontinfo.plist
+++ b/source/Ubuntu-C.ufo/fontinfo.plist
@@ -128,8 +128,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Condensed Regular Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-L.ufo/fontinfo.plist
+++ b/source/Ubuntu-L.ufo/fontinfo.plist
@@ -94,8 +94,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Light Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-LI.ufo/fontinfo.plist
+++ b/source/Ubuntu-LI.ufo/fontinfo.plist
@@ -134,8 +134,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Light Italic Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>Version 0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-M.ufo/fontinfo.plist
+++ b/source/Ubuntu-M.ufo/fontinfo.plist
@@ -102,8 +102,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Medium Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>Version 0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-MI.ufo/fontinfo.plist
+++ b/source/Ubuntu-MI.ufo/fontinfo.plist
@@ -94,8 +94,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Medium Italic Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>Version 0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-R.ufo/fontinfo.plist
+++ b/source/Ubuntu-R.ufo/fontinfo.plist
@@ -108,8 +108,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Regular Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>Version 0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/Ubuntu-RI.ufo/fontinfo.plist
+++ b/source/Ubuntu-RI.ufo/fontinfo.plist
@@ -96,8 +96,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Regular Version 0.83</string>
 		<key>openTypeNameVersion</key>
 		<string>Version 0.83</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/UbuntuMono-B.ufo/fontinfo.plist
+++ b/source/UbuntuMono-B.ufo/fontinfo.plist
@@ -70,8 +70,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Mono Bold Version 0.80</string>
 		<key>openTypeNameVersion</key>
 		<string>Version 0.80</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/UbuntuMono-BI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-BI.ufo/fontinfo.plist
@@ -78,8 +78,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Mono Bold Italic Version 0.80</string>
 		<key>openTypeNameVersion</key>
 		<string>Version 0.80</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/UbuntuMono-R.ufo/fontinfo.plist
+++ b/source/UbuntuMono-R.ufo/fontinfo.plist
@@ -70,8 +70,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Mono Regular Version 0.80</string>
 		<key>openTypeNameVersion</key>
 		<string>Version 0.80</string>
 		<key>openTypeOS2CodePageRanges</key>

--- a/source/UbuntuMono-RI.ufo/fontinfo.plist
+++ b/source/UbuntuMono-RI.ufo/fontinfo.plist
@@ -70,8 +70,6 @@ The scope of the Ubuntu Font Family includes all the languages used by the vario
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
-		<key>openTypeNameUniqueID</key>
-		<string>Ubuntu Mono Italic Version 0.80</string>
 		<key>openTypeNameVersion</key>
 		<string>Version 0.80</string>
 		<key>openTypeOS2CodePageRanges</key>


### PR DESCRIPTION
Unnecessary and the font compiler will generate something closer to what
the GF version has: "Version;Vendor;Postscript-Name".

Some GF fonts use the format, others use the one that's removed here. 