### PR TITLE
Set familyName to 'Ubuntu' in proportional UFOs

### DIFF
--- a/source/Ubuntu-C.ufo/fontinfo.plist
+++ b/source/Ubuntu-C.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Condensed</string>
+		<string>Ubuntu</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -121,6 +121,10 @@
 		<string>Dalton Maag Ltd</string>
 		<key>openTypeNameManufacturerURL</key>
 		<string>http://www.daltonmaag.com/</string>
+		<key>openTypeNamePreferredFamilyName</key>
+		<string>Ubuntu Condensed</string>
+		<key>openTypeNamePreferredSubfamilyName</key>
+		<string>Regular</string>
 		<key>openTypeNameRecords</key>
 		<array>
 		</array>
@@ -285,7 +289,7 @@
 		<key>styleMapStyleName</key>
 		<string>regular</string>
 		<key>styleName</key>
-		<string>Regular</string>
+		<string>Condensed</string>
 		<key>trademark</key>
 		<string>Ubuntu and Canonical are registered trademarks of Canonical Ltd.</string>
 		<key>unitsPerEm</key>

--- a/source/Ubuntu-L.ufo/fontinfo.plist
+++ b/source/Ubuntu-L.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Light</string>
+		<string>Ubuntu</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -243,7 +243,7 @@
 		<key>styleMapStyleName</key>
 		<string>regular</string>
 		<key>styleName</key>
-		<string>Regular</string>
+		<string>Light</string>
 		<key>trademark</key>
 		<string>Ubuntu and Canonical are registered trademarks of Canonical Ltd.</string>
 		<key>unitsPerEm</key>

--- a/source/Ubuntu-LI.ufo/fontinfo.plist
+++ b/source/Ubuntu-LI.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Light</string>
+		<string>Ubuntu</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -283,7 +283,7 @@
 		<key>styleMapStyleName</key>
 		<string>italic</string>
 		<key>styleName</key>
-		<string>Italic</string>
+		<string>Light Italic</string>
 		<key>trademark</key>
 		<string>Ubuntu and Canonical are registered trademarks of Canonical Ltd.</string>
 		<key>unitsPerEm</key>

--- a/source/Ubuntu-M.ufo/fontinfo.plist
+++ b/source/Ubuntu-M.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Medium</string>
+		<string>Ubuntu</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -251,7 +251,7 @@
 		<key>styleMapStyleName</key>
 		<string>regular</string>
 		<key>styleName</key>
-		<string>Regular</string>
+		<string>Medium</string>
 		<key>trademark</key>
 		<string>Ubuntu and Canonical are registered trademarks of Canonical Ltd.</string>
 		<key>unitsPerEm</key>

--- a/source/Ubuntu-MI.ufo/fontinfo.plist
+++ b/source/Ubuntu-MI.ufo/fontinfo.plist
@@ -11,7 +11,7 @@
 		<key>descender</key>
 		<integer>-185</integer>
 		<key>familyName</key>
-		<string>Ubuntu Medium</string>
+		<string>Ubuntu</string>
 		<key>guidelines</key>
 		<array>
 			<dict>
@@ -251,7 +251,7 @@
 		<key>styleMapStyleName</key>
 		<string>italic</string>
 		<key>styleName</key>
-		<string>Italic</string>
+		<string>Medium Italic</string>
 		<key>trademark</key>
 		<string>Ubuntu and Canonical are registered trademarks of Canonical Ltd.</string>
 		<key>unitsPerEm</key>


### PR DESCRIPTION
Change styleName accordingly in proportional UFOs

Set openTypeNamePreferredFamilyName and openTypeNamePreferredSubfamilyName
to 'Ubuntu Condensed' and 'Regular' for Ubuntu-C.ufo.